### PR TITLE
Add NVIDIA GPU core voltage and memory temperature stats to GUI

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -106,6 +106,7 @@ pub struct GpuInfo {
     pub load: Option<f32>,
     pub power: Option<f32>,
     pub voltage: Option<f32>,
+    pub memory_temperature: Option<f32>,
     pub freq_offset: Option<i32>,
     pub drain_offset: Option<i32>,
     pub power_offset: Option<i32>,

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -1194,6 +1194,7 @@ pub fn get_gpu_info() -> Result<Vec<GpuInfo>> {
                 load,
                 power,
                 voltage,
+                memory_temperature: None,
                 freq_offset: None,
                 drain_offset: None,
                 power_offset: None,
@@ -1380,6 +1381,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 load: None,
                 power: None,
                 voltage: None,
+                memory_temperature: None,
                 freq_offset: None,
                 drain_offset: None,
                 power_offset: None,
@@ -1450,7 +1452,44 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             )
         };
 
-        let voltage = if is_suspended { None } else { get_nvidia_voltage(i) };
+        let (ioctl_voltage, memory_temperature) = if is_suspended {
+            (None, None)
+        } else {
+            match crate::nvidia_driver::NvidiaDriverHandle::open(device.minor_number().unwrap_or(i)) {
+                Ok(handle) => {
+                    let voltage = handle.get_voltage(crate::nvidia_driver::NV2080_CTRL_VOLT_DOMAIN_CORE)
+                        .ok()
+                        .map(|uv| uv as f32 / 1_000_000.0);
+
+                    let mut vram_temp = None;
+                    if let Ok(sensors) = handle.get_thermal_sensors_info() {
+                        let mut vram_sensor_id = None;
+                        for (id, sensor_type) in sensors {
+                            if sensor_type == crate::nvidia_driver::NV2080_CTRL_THERMAL_SENSOR_TYPE_MEMORY || id == 15 {
+                                vram_sensor_id = Some(id);
+                                break;
+                            }
+                        }
+
+                        if let Some(id) = vram_sensor_id {
+                            if let Ok(temps) = handle.get_temperatures(1 << id) {
+                                if let Some((_, temp_raw)) = temps.first() {
+                                    vram_temp = Some(*temp_raw as f32 / 256.0);
+                                }
+                            }
+                        }
+                    }
+                    (voltage, vram_temp)
+                }
+                Err(_) => (None, None),
+            }
+        };
+
+        let voltage = if is_suspended {
+            None
+        } else {
+            ioctl_voltage.or_else(|| get_nvidia_voltage(i))
+        };
 
         let mut gpu_info = GpuInfo {
             name: name.clone(),
@@ -1462,6 +1501,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             load,
             power,
             voltage,
+            memory_temperature,
             freq_offset: None,
             drain_offset: None,
             power_offset: None,

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -1462,19 +1462,31 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                         .map(|uv| uv as f32 / 1_000_000.0);
 
                     let mut vram_temp = None;
-                    if let Ok(sensors) = handle.get_thermal_sensors_info() {
-                        let mut vram_sensor_id = None;
-                        for (id, sensor_type) in sensors {
-                            if sensor_type == crate::nvidia_driver::NV2080_CTRL_THERMAL_SENSOR_TYPE_MEMORY || id == 15 {
-                                vram_sensor_id = Some(id);
-                                break;
-                            }
+                    // Try get_all_thermals first (one-shot call)
+                    if let Ok(thermals) = handle.get_all_thermals() {
+                        for (_id, sensor_type, temp) in thermals {
+                             if sensor_type == crate::nvidia_driver::NV2080_CTRL_THERMAL_SENSOR_TYPE_MEMORY {
+                                 vram_temp = Some(temp);
+                                 break;
+                             }
                         }
+                    }
 
-                        if let Some(id) = vram_sensor_id {
-                            if let Ok(temps) = handle.get_temperatures(1 << id) {
-                                if let Some((_, temp_raw)) = temps.first() {
-                                    vram_temp = Some(*temp_raw as f32 / 256.0);
+                    if vram_temp.is_none() {
+                        if let Ok(sensors) = handle.get_thermal_sensors_info() {
+                            let mut vram_sensor_id = None;
+                            for (id, sensor_type) in sensors {
+                                if sensor_type == crate::nvidia_driver::NV2080_CTRL_THERMAL_SENSOR_TYPE_MEMORY || id == 15 {
+                                    vram_sensor_id = Some(id);
+                                    break;
+                                }
+                            }
+
+                            if let Some(id) = vram_sensor_id {
+                                if let Ok(temps) = handle.get_temperatures(1 << id) {
+                                    if let Some((_, temp_raw)) = temps.first() {
+                                        vram_temp = Some(*temp_raw as f32 / 256.0);
+                                    }
                                 }
                             }
                         }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,6 +1,7 @@
 mod dbus_interface;
 mod hardware_control;
 mod hardware_detection;
+mod nvidia_driver;
 mod tuxedo_io;
 mod battery_control;
 mod polling_scheduler;

--- a/daemon/src/nvidia_driver.rs
+++ b/daemon/src/nvidia_driver.rs
@@ -1,0 +1,275 @@
+use std::{
+    ffi::c_void,
+    fs::File,
+    mem,
+    os::fd::{AsRawFd, RawFd},
+    ptr,
+};
+use anyhow::{bail, Context, Result};
+use nix::ioctl_readwrite;
+
+pub const NV_IOCTL_MAGIC: u8 = b'F';
+pub const NV_ESC_RM_ALLOC: u8 = 0x2b;
+pub const NV_ESC_RM_CONTROL: u8 = 0x2a;
+pub const NV_ESC_REGISTER_FD: u8 = 0x27;
+
+pub const NV01_DEVICE_0: u32 = 0x00000080;
+pub const NV20_SUBDEVICE_0: u32 = 0x00002080;
+
+pub const NV2080_CTRL_CMD_THERMAL_GET_TEMPERATURES: u32 = 0x20800501;
+pub const NV2080_CTRL_CMD_THERMAL_GET_THERMAL_SENSORS_INFO: u32 = 0x20800502;
+pub const NV2080_THERMAL_SENSORS_MAX_COUNT: usize = 32;
+
+pub const NV2080_CTRL_CMD_VOLT_GET_VOLTAGE: u32 = 0x20803201;
+pub const NV2080_CTRL_VOLT_DOMAIN_CORE: u32 = 0x00000000;
+
+pub const NV2080_CTRL_THERMAL_SENSOR_TYPE_MEMORY: u32 = 0x00000002;
+
+type NvHandle = u32;
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct NVOS21_PARAMETERS {
+    hRoot: NvHandle,
+    hObjectParent: NvHandle,
+    hObjectNew: NvHandle,
+    hClass: u32,
+    pAllocParms: *mut c_void,
+    status: u32,
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct NVOS64_PARAMETERS {
+    hRoot: NvHandle,
+    hObjectParent: NvHandle,
+    hObjectNew: NvHandle,
+    hClass: u32,
+    pAllocParms: *mut c_void,
+    pRightsRequested: *mut c_void,
+    paramsSize: u32,
+    flags: u32,
+    status: u32,
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct NV0080_ALLOC_PARAMETERS {
+    deviceId: u32,
+    hClientShare: NvHandle,
+    hTargetClient: NvHandle,
+    hTargetDevice: NvHandle,
+    flags: u32,
+    pad0: [u32; 2],
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct NV2080_ALLOC_PARAMETERS {
+    reserved: u32,
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct NVOS54_PARAMETERS {
+    hClient: NvHandle,
+    hObject: NvHandle,
+    cmd: u32,
+    flags: u32,
+    params: *mut c_void,
+    paramsSize: u32,
+    status: u32,
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct NV2080_CTRL_THERMAL_GET_TEMPERATURES_PARAMS {
+    mask: u32,
+    temperatures: [i32; NV2080_THERMAL_SENSORS_MAX_COUNT],
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+struct NV2080_CTRL_THERMAL_GET_THERMAL_SENSORS_INFO_PARAMS {
+    sensorCount: u32,
+    sensorInfo: [NV2080_CTRL_THERMAL_SENSOR_INFO; NV2080_THERMAL_SENSORS_MAX_COUNT],
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+struct NV2080_CTRL_THERMAL_SENSOR_INFO {
+    sensorId: u32,
+    sensorType: u32,
+    controllerId: u32,
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct NV2080_CTRL_VOLT_GET_VOLTAGE_PARAMS {
+    voltDomainId: u32,
+    voltageuV: u32,
+}
+
+ioctl_readwrite!(rm_alloc_nvos21, NV_IOCTL_MAGIC, NV_ESC_RM_ALLOC, NVOS21_PARAMETERS);
+ioctl_readwrite!(rm_alloc_nvos64, NV_IOCTL_MAGIC, NV_ESC_RM_ALLOC, NVOS64_PARAMETERS);
+ioctl_readwrite!(register_fd, NV_IOCTL_MAGIC, NV_ESC_REGISTER_FD, RawFd);
+ioctl_readwrite!(rm_control_nvos54, NV_IOCTL_MAGIC, NV_ESC_RM_CONTROL, NVOS54_PARAMETERS);
+
+pub struct NvidiaDriverHandle {
+    nvidiactl_fd: File,
+    #[allow(dead_code)]
+    device_fd: File,
+    client_handle: NvHandle,
+    #[allow(dead_code)]
+    device_handle: NvHandle,
+    subdevice_handle: NvHandle,
+}
+
+impl NvidiaDriverHandle {
+    pub fn open(minor_number: u32) -> Result<Self> {
+        let nvidiactl_fd = File::options()
+            .read(true)
+            .write(true)
+            .open("/dev/nvidiactl")
+            .context("Could not open nvidiactl")?;
+
+        let client_handle: NvHandle = unsafe {
+            let mut client_request: NVOS21_PARAMETERS = mem::zeroed();
+            rm_alloc_nvos21(nvidiactl_fd.as_raw_fd(), &raw mut client_request)?;
+            client_request.hObjectNew
+        };
+
+        let device_fd = File::options()
+            .read(true)
+            .write(true)
+            .open(format!("/dev/nvidia{minor_number}"))
+            .context("Could not open nvidia device")?;
+
+        let device_handle: NvHandle = unsafe {
+            let mut fd = device_fd.as_raw_fd();
+            register_fd(nvidiactl_fd.as_raw_fd(), &mut fd)?;
+
+            let mut alloc_params: NV0080_ALLOC_PARAMETERS = mem::zeroed();
+            alloc_params.deviceId = minor_number;
+            let mut request = NVOS64_PARAMETERS {
+                hRoot: client_handle,
+                hObjectParent: client_handle,
+                hObjectNew: 0,
+                hClass: NV01_DEVICE_0,
+                pAllocParms: ptr::from_mut(&mut alloc_params).cast::<c_void>(),
+                pRightsRequested: ptr::null_mut(),
+                paramsSize: mem::size_of::<NV0080_ALLOC_PARAMETERS>() as u32,
+                flags: 0,
+                status: 0,
+            };
+
+            rm_alloc_nvos64(nvidiactl_fd.as_raw_fd(), &raw mut request)?;
+
+            if request.status != 0 {
+                bail!("Got error status 0x{:x} on Nvidia device handle creation", request.status);
+            }
+
+            request.hObjectNew
+        };
+
+        let subdevice_handle: NvHandle = unsafe {
+            let mut alloc_params: NV2080_ALLOC_PARAMETERS = mem::zeroed();
+
+            let mut request = NVOS64_PARAMETERS {
+                hRoot: client_handle,
+                hObjectParent: device_handle,
+                hObjectNew: 0,
+                hClass: NV20_SUBDEVICE_0,
+                pAllocParms: ptr::from_mut(&mut alloc_params).cast(),
+                pRightsRequested: ptr::null_mut(),
+                paramsSize: mem::size_of::<NV2080_ALLOC_PARAMETERS>() as u32,
+                flags: 0,
+                status: 0,
+            };
+
+            rm_alloc_nvos64(nvidiactl_fd.as_raw_fd(), &raw mut request)?;
+
+            if request.status != 0 {
+                bail!("Got error status 0x{:x} on Nvidia subdevice handle creation", request.status);
+            }
+
+            request.hObjectNew
+        };
+
+        Ok(Self {
+            nvidiactl_fd,
+            device_fd,
+            client_handle,
+            device_handle,
+            subdevice_handle,
+        })
+    }
+
+    fn query_rm_control<T: Copy>(&self, cmd: u32, params: &mut T) -> Result<()> {
+        let mut request = NVOS54_PARAMETERS {
+            hClient: self.client_handle,
+            hObject: self.subdevice_handle,
+            cmd,
+            flags: 0,
+            params: ptr::from_mut(params).cast(),
+            paramsSize: mem::size_of::<T>().try_into().unwrap(),
+            status: 0,
+        };
+        unsafe {
+            rm_control_nvos54(self.nvidiactl_fd.as_raw_fd(), &raw mut request)?;
+        }
+
+        if request.status != 0 {
+            bail!("Nvidia request failed with status 0x{:x}", request.status);
+        }
+
+        Ok(())
+    }
+
+    pub fn get_thermal_sensors_info(&self) -> Result<Vec<(u32, u32)>> {
+        let mut params = NV2080_CTRL_THERMAL_GET_THERMAL_SENSORS_INFO_PARAMS::default();
+        self.query_rm_control(NV2080_CTRL_CMD_THERMAL_GET_THERMAL_SENSORS_INFO, &mut params)?;
+
+        let sensors = params.sensorInfo[..params.sensorCount as usize]
+            .iter()
+            .map(|info| (info.sensorId, info.sensorType))
+            .collect();
+
+        Ok(sensors)
+    }
+
+    pub fn get_temperatures(&self, mask: u32) -> Result<Vec<(u32, i32)>> {
+        let mut params = NV2080_CTRL_THERMAL_GET_TEMPERATURES_PARAMS {
+            mask,
+            temperatures: [0; NV2080_THERMAL_SENSORS_MAX_COUNT],
+        };
+        self.query_rm_control(NV2080_CTRL_CMD_THERMAL_GET_TEMPERATURES, &mut params)?;
+
+        let mut results = Vec::new();
+        for i in 0..NV2080_THERMAL_SENSORS_MAX_COUNT {
+            if (mask & (1 << i)) != 0 {
+                results.push((i as u32, params.temperatures[i]));
+            }
+        }
+
+        Ok(results)
+    }
+
+    pub fn get_voltage(&self, domain_id: u32) -> Result<u32> {
+        let mut params = NV2080_CTRL_VOLT_GET_VOLTAGE_PARAMS {
+            voltDomainId: domain_id,
+            voltageuV: 0,
+        };
+        self.query_rm_control(NV2080_CTRL_CMD_VOLT_GET_VOLTAGE, &mut params)?;
+        Ok(params.voltageuV)
+    }
+}

--- a/daemon/src/nvidia_driver.rs
+++ b/daemon/src/nvidia_driver.rs
@@ -18,9 +18,11 @@ pub const NV20_SUBDEVICE_0: u32 = 0x00002080;
 
 pub const NV2080_CTRL_CMD_THERMAL_GET_TEMPERATURES: u32 = 0x20800501;
 pub const NV2080_CTRL_CMD_THERMAL_GET_THERMAL_SENSORS_INFO: u32 = 0x20800502;
+pub const NV2080_CTRL_CMD_THERMAL_GET_ALL_THERMAL_SENSORS_INFO: u32 = 0x65fe3aad;
 pub const NV2080_THERMAL_SENSORS_MAX_COUNT: usize = 32;
 
 pub const NV2080_CTRL_CMD_VOLT_GET_VOLTAGE: u32 = 0x20803201;
+pub const NV2080_CTRL_CMD_VOLT_GET_VOLTAGE_EX: u32 = 0x465f9bcf;
 pub const NV2080_CTRL_VOLT_DOMAIN_CORE: u32 = 0x00000000;
 
 pub const NV2080_CTRL_THERMAL_SENSOR_TYPE_MEMORY: u32 = 0x00000002;
@@ -109,6 +111,27 @@ struct NV2080_CTRL_THERMAL_SENSOR_INFO {
     sensorId: u32,
     sensorType: u32,
     controllerId: u32,
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct NV2080_CTRL_THERMAL_GET_ALL_THERMAL_SENSORS_INFO_PARAMS {
+    sensorCount: u32,
+    sensorInfo: [NV2080_CTRL_THERMAL_ALL_SENSOR_INFO; NV2080_THERMAL_SENSORS_MAX_COUNT],
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+struct NV2080_CTRL_THERMAL_ALL_SENSOR_INFO {
+    sensorId: u32,
+    sensorType: u32,
+    controllerId: u32,
+    currentTemp: i32,
+    warnTemp: i32,
+    critTemp: i32,
+    unknown: u32,
 }
 
 #[allow(non_snake_case)]
@@ -269,7 +292,24 @@ impl NvidiaDriverHandle {
             voltDomainId: domain_id,
             voltageuV: 0,
         };
-        self.query_rm_control(NV2080_CTRL_CMD_VOLT_GET_VOLTAGE, &mut params)?;
+        // Try standard first, then EX
+        if let Err(_) = self.query_rm_control(NV2080_CTRL_CMD_VOLT_GET_VOLTAGE, &mut params) {
+             self.query_rm_control(NV2080_CTRL_CMD_VOLT_GET_VOLTAGE_EX, &mut params)?;
+        }
         Ok(params.voltageuV)
+    }
+
+    pub fn get_all_thermals(&self) -> Result<Vec<(u32, u32, f32)>> {
+        let mut params: NV2080_CTRL_THERMAL_GET_ALL_THERMAL_SENSORS_INFO_PARAMS = unsafe { mem::zeroed() };
+        self.query_rm_control(NV2080_CTRL_CMD_THERMAL_GET_ALL_THERMAL_SENSORS_INFO, &mut params)?;
+
+        let mut results = Vec::new();
+        for i in 0..params.sensorCount as usize {
+            if i < NV2080_THERMAL_SENSORS_MAX_COUNT {
+                let entry = &params.sensorInfo[i];
+                results.push((entry.sensorId, entry.sensorType, entry.currentTemp as f32 / 256.0));
+            }
+        }
+        Ok(results)
     }
 }

--- a/gui/src/pages/statistics.rs
+++ b/gui/src/pages/statistics.rs
@@ -387,10 +387,19 @@ fn draw_gpu_info(ui: &mut Ui, state: &AppState) {
                             }
                             
                             if let Some(temp) = gpu.temperature {
-                                ui.label("Temperature:");
+                                ui.label("Core Temperature:");
                                 ui.colored_label(
                                     temp_color(temp),
                                     format!("{:.1}°C", temp)
+                                );
+                                ui.end_row();
+                            }
+
+                            if let Some(mem_temp) = gpu.memory_temperature {
+                                ui.label("Memory Temperature:");
+                                ui.colored_label(
+                                    temp_color(mem_temp),
+                                    format!("{:.1}°C", mem_temp)
                                 );
                                 ui.end_row();
                             }
@@ -412,7 +421,7 @@ fn draw_gpu_info(ui: &mut Ui, state: &AppState) {
                             }
 
                             if let Some(voltage) = gpu.voltage {
-                                ui.label("Voltage:");
+                                ui.label("Core Voltage:");
                                 ui.label(format!("{:.3} V", voltage));
                                 ui.end_row();
                             }

--- a/nvidia/nvapi.rs
+++ b/nvidia/nvapi.rs
@@ -1,0 +1,2 @@
+pub const QUERY_NVAPI_THERMALS: u32 = 0x65fe3aad; // Undocumented call
+pub const QUERY_NVAPI_VOLTAGE: u32 = 0x465f9bcf; // Undocumented call


### PR DESCRIPTION
This submission adds NVIDIA GPU core voltage and memory temperature statistics to the LapSphere GUI. It implements a new `nvidia_driver` module in the daemon that uses low-level ioctls to communicate with the NVIDIA driver, allowing for more detailed hardware monitoring than what is typically available through high-level APIs. The GUI now displays Core Temperature, Memory Temperature, and Core Voltage, and these statistics are only updated when the GPU is active.

---
*PR created automatically by Jules for task [13392154916465684356](https://jules.google.com/task/13392154916465684356) started by @weter11*