### PR TITLE
Add NVIDIA GPU core voltage and temperature stats via NVAPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,6 +1791,7 @@ dependencies = [
  "env_logger",
  "lapsphere-common",
  "libc",
+ "libloading",
  "log",
  "nix",
  "nvml-wrapper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ anyhow = "1.0"
 systemstat = "0.2"
 once_cell = "1"
 nix = "0.29"
+libloading = "0.8"
 webbrowser = "1.0"
 lapsphere-common = { path = "./common" }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -104,6 +104,7 @@ pub struct GpuInfo {
     pub memory_frequency: Option<u64>,
     pub temperature: Option<f32>,
     pub memory_temperature: Option<f32>,
+    pub hotspot_temperature: Option<f32>,
     pub load: Option<f32>,
     pub power: Option<f32>,
     pub voltage: Option<f32>,

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -103,6 +103,7 @@ pub struct GpuInfo {
     pub frequency: Option<u64>,
     pub memory_frequency: Option<u64>,
     pub temperature: Option<f32>,
+    pub memory_temperature: Option<f32>,
     pub load: Option<f32>,
     pub power: Option<f32>,
     pub voltage: Option<f32>,

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -17,5 +17,6 @@ tokio = { workspace = true, features = ["full"] }
 libc = "0.2"
 nix = { workspace = true, features = ["ioctl", "signal"] }
 nvml-wrapper = "0.11.0"
+libloading.workspace = true
 once_cell.workspace = true
 systemstat.workspace = true

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -6,9 +6,12 @@ use std::sync::Mutex;
 use std::time::Instant;
 use once_cell::sync::Lazy;
 use crate::tuxedo_io::{TuxedoIo, HardwareInterface};
+use crate::nvapi::NvApi;
 use systemstat::{System, Platform};
 // use tuxedo_io::TuxedoIo;
 use lapsphere_common::types::*;
+
+static NVAPI: Lazy<Option<NvApi>> = Lazy::new(|| NvApi::new().ok());
 
 // Thread-safe storage for previous CPU stats
 static PREVIOUS_CPU_STATS: Mutex<Option<HashMap<u32, CpuStats>>> = Mutex::new(None);
@@ -1191,6 +1194,7 @@ pub fn get_gpu_info() -> Result<Vec<GpuInfo>> {
                 frequency,
                 memory_frequency,
                 temperature,
+                memory_temperature: None,
                 load,
                 power,
                 voltage,
@@ -1377,6 +1381,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 frequency: None,
                 memory_frequency: None,
                 temperature: None,
+                memory_temperature: None,
                 load: None,
                 power: None,
                 voltage: None,
@@ -1432,9 +1437,24 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             }
         };
 
-        let (frequency, memory_frequency, temperature, load, power) = if is_suspended {
-            (None, None, None, None, None)
+        let pci_info = device.pci_info().ok();
+        let bus_id = pci_info.map(|p| p.bus);
+
+        let (frequency, memory_frequency, temperature, memory_temperature, load, power, voltage) = if is_suspended {
+            (None, None, None, None, None, None, None)
         } else {
+            let (nvapi_voltage, nvapi_temp, nvapi_mem_temp) = if let (Some(ref api), Some(bus_id)) = (&*NVAPI, bus_id) {
+                if let Ok(Some(handle)) = api.find_matching_gpu(bus_id) {
+                    let v = unsafe { api.get_voltage(handle).ok().map(|v| v as f32 / 1_000_000.0) };
+                    let t = unsafe { api.get_thermals(handle).ok() };
+                    (v, t.as_ref().and_then(|t| t.core()), t.as_ref().and_then(|t| t.vram()))
+                } else {
+                    (None, None, None)
+                }
+            } else {
+                (None, None, None)
+            };
+
             (
                 device.clock_info(nvml_wrapper::enum_wrappers::device::Clock::Graphics)
                     .ok()
@@ -1442,15 +1462,15 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 device.clock_info(nvml_wrapper::enum_wrappers::device::Clock::Memory)
                     .ok()
                     .map(|c| c as u64),
-                device.temperature(nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu)
+                nvapi_temp.or_else(|| device.temperature(nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu)
                     .ok()
-                    .map(|t| t as f32),
+                    .map(|t| t as f32)),
+                nvapi_mem_temp,
                 device.utilization_rates().ok().map(|u| u.gpu as f32),
                 device.power_usage().ok().map(|p| p as f32 / 1000.0),
+                nvapi_voltage.or_else(|| get_nvidia_voltage(i)),
             )
         };
-
-        let voltage = if is_suspended { None } else { get_nvidia_voltage(i) };
 
         let mut gpu_info = GpuInfo {
             name: name.clone(),
@@ -1459,6 +1479,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             frequency,
             memory_frequency,
             temperature,
+            memory_temperature,
             load,
             power,
             voltage,

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -1457,15 +1457,30 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             (None, None, None, None, None, None, None, None)
         } else {
             let (nvapi_voltage, nvapi_temp, nvapi_mem_temp, nvapi_hotspot_temp) = if let (Some(ref api), Some(bus_id)) = (&*NVAPI, bus_id) {
-                if let Ok(Some(handle)) = api.find_matching_gpu(bus_id) {
-                    let v = unsafe { api.get_voltage(handle).ok().map(|v| v as f32 / 1_000_000.0) };
-                    let t = unsafe { api.get_thermals(handle, -1).ok() };
-                    (v,
-                     t.as_ref().and_then(|t| t.core()),
-                     t.as_ref().and_then(|t| t.vram()),
-                     t.as_ref().and_then(|t| t.hotspot()))
-                } else {
-                    (None, None, None, None)
+                match api.find_matching_gpu(bus_id) {
+                    Ok(Some(handle)) => {
+                        let v = unsafe { api.get_voltage(handle).ok() }
+                            .map(|v| v as f32 / 1_000_000.0)
+                            .filter(|&v| v > 0.1);
+
+                        let t = unsafe { api.get_thermals(handle, -1).ok() };
+                        let core = t.as_ref().and_then(|t| t.core());
+                        let vram = t.as_ref().and_then(|t| t.vram());
+                        let hotspot = t.as_ref().and_then(|t| t.hotspot());
+
+                        log::debug!("NVAPI stats for GPU {}: voltage={:?}, core={:?}, vram={:?}, hotspot={:?}",
+                                   bus_id, v, core, vram, hotspot);
+
+                        (v, core, vram, hotspot)
+                    }
+                    Ok(None) => {
+                        log::debug!("No NVAPI handle for GPU bus ID {}", bus_id);
+                        (None, None, None, None)
+                    }
+                    Err(e) => {
+                        log::warn!("NVAPI error for GPU bus ID {}: {}", bus_id, e);
+                        (None, None, None, None)
+                    }
                 }
             } else {
                 (None, None, None, None)

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -11,7 +11,18 @@ use systemstat::{System, Platform};
 // use tuxedo_io::TuxedoIo;
 use lapsphere_common::types::*;
 
-static NVAPI: Lazy<Option<NvApi>> = Lazy::new(|| NvApi::new().ok());
+static NVAPI: Lazy<Option<NvApi>> = Lazy::new(|| {
+    match NvApi::new() {
+        Ok(api) => {
+            log::info!("NVIDIA API initialized successfully");
+            Some(api)
+        }
+        Err(e) => {
+            log::warn!("Failed to initialize NVIDIA API: {}", e);
+            None
+        }
+    }
+});
 
 // Thread-safe storage for previous CPU stats
 static PREVIOUS_CPU_STATS: Mutex<Option<HashMap<u32, CpuStats>>> = Mutex::new(None);
@@ -1195,6 +1206,7 @@ pub fn get_gpu_info() -> Result<Vec<GpuInfo>> {
                 memory_frequency,
                 temperature,
                 memory_temperature: None,
+                hotspot_temperature: None,
                 load,
                 power,
                 voltage,
@@ -1382,6 +1394,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 memory_frequency: None,
                 temperature: None,
                 memory_temperature: None,
+                hotspot_temperature: None,
                 load: None,
                 power: None,
                 voltage: None,
@@ -1440,19 +1453,22 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         let pci_info = device.pci_info().ok();
         let bus_id = pci_info.map(|p| p.bus);
 
-        let (frequency, memory_frequency, temperature, memory_temperature, load, power, voltage) = if is_suspended {
-            (None, None, None, None, None, None, None)
+        let (frequency, memory_frequency, temperature, memory_temperature, hotspot_temperature, load, power, voltage) = if is_suspended {
+            (None, None, None, None, None, None, None, None)
         } else {
-            let (nvapi_voltage, nvapi_temp, nvapi_mem_temp) = if let (Some(ref api), Some(bus_id)) = (&*NVAPI, bus_id) {
+            let (nvapi_voltage, nvapi_temp, nvapi_mem_temp, nvapi_hotspot_temp) = if let (Some(ref api), Some(bus_id)) = (&*NVAPI, bus_id) {
                 if let Ok(Some(handle)) = api.find_matching_gpu(bus_id) {
                     let v = unsafe { api.get_voltage(handle).ok().map(|v| v as f32 / 1_000_000.0) };
-                    let t = unsafe { api.get_thermals(handle).ok() };
-                    (v, t.as_ref().and_then(|t| t.core()), t.as_ref().and_then(|t| t.vram()))
+                    let t = unsafe { api.get_thermals(handle, -1).ok() };
+                    (v,
+                     t.as_ref().and_then(|t| t.core()),
+                     t.as_ref().and_then(|t| t.vram()),
+                     t.as_ref().and_then(|t| t.hotspot()))
                 } else {
-                    (None, None, None)
+                    (None, None, None, None)
                 }
             } else {
-                (None, None, None)
+                (None, None, None, None)
             };
 
             (
@@ -1466,6 +1482,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                     .ok()
                     .map(|t| t as f32)),
                 nvapi_mem_temp,
+                nvapi_hotspot_temp,
                 device.utilization_rates().ok().map(|u| u.gpu as f32),
                 device.power_usage().ok().map(|p| p as f32 / 1000.0),
                 nvapi_voltage.or_else(|| get_nvidia_voltage(i)),
@@ -1480,6 +1497,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             memory_frequency,
             temperature,
             memory_temperature,
+            hotspot_temperature,
             load,
             power,
             voltage,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,4 +1,5 @@
 mod dbus_interface;
+mod nvapi;
 mod hardware_control;
 mod hardware_detection;
 mod tuxedo_io;

--- a/daemon/src/nvapi.rs
+++ b/daemon/src/nvapi.rs
@@ -32,6 +32,7 @@ pub struct NvApi {
 
 impl NvApi {
     pub fn new() -> anyhow::Result<Self> {
+        log::debug!("Loading NVIDIA API library: {}", LIBRARY_NAME);
         let lib = unsafe {
             libloading::Library::new(LIBRARY_NAME).context("Could not load nvidia API library")
         }?;
@@ -42,15 +43,17 @@ impl NvApi {
             let initialize = handle.query_interface(QUERY_NVAPI_INITIALIZE)?;
             let initialize: unsafe extern "C" fn() -> NvAPI_Status = transmute(initialize);
             let status = initialize();
-            handle.handle_status(status)?;
+            handle.handle_status(status).context("NvAPI_Initialize failed")?;
         }
 
+        log::debug!("NVIDIA API initialized successfully");
         Ok(handle)
     }
 
     pub fn find_matching_gpu(&self, bus_id: u32) -> anyhow::Result<Option<NvPhysicalGpuHandle>> {
         unsafe {
             let handles = self.enum_physical_gpus()?;
+            log::debug!("Found {} physical GPUs via NVAPI", handles.len());
             for handle in handles {
                 let f = self.query_interface(QUERY_NVAPI_GET_BUS_ID)?;
                 let f: unsafe extern "C" fn(
@@ -62,11 +65,13 @@ impl NvApi {
                 let status = f(handle, &mut id);
                 self.handle_status(status)?;
 
+                log::debug!("GPU handle {:?} has bus ID {}", handle, id);
                 if id == bus_id {
                     return Ok(Some(handle));
                 }
             }
 
+            log::warn!("No GPU matching bus ID {} found in NVAPI", bus_id);
             Ok(None)
         }
     }
@@ -74,6 +79,7 @@ impl NvApi {
     pub unsafe fn get_thermals(
         &self,
         handle: NvPhysicalGpuHandle,
+        mask: i32,
     ) -> anyhow::Result<NvApiThermals> {
         let f = self.query_interface(QUERY_NVAPI_THERMALS)?;
         let f: unsafe extern "C" fn(
@@ -84,12 +90,12 @@ impl NvApi {
         let mut sensors = NvApiThermals {
             #[allow(clippy::cast_possible_truncation)]
             version: (mem::size_of::<NvApiThermals>() | (2 << 16)) as u32,
-            count: 0,
-            sensors: [NvApiThermalSensor::default(); 8],
+            mask,
+            values: [0; 40],
         };
 
         let status = f(handle, &mut sensors);
-        self.handle_status(status)?;
+        self.handle_status(status).context("QUERY_NVAPI_THERMALS failed")?;
 
         Ok(sensors)
     }
@@ -105,11 +111,12 @@ impl NvApi {
             #[allow(clippy::cast_possible_truncation)]
             version: (mem::size_of::<NvApiVoltage>() | (1 << 16)) as u32,
             flags: 0,
+            padding_1: [0; 8],
             value_uv: 0,
-            padding: [0; 16],
+            padding_2: [0; 8],
         };
         let status = f(handle, &mut data);
-        self.handle_status(status)?;
+        self.handle_status(status).context("QUERY_NVAPI_VOLTAGE failed")?;
 
         Ok(data.value_uv)
     }
@@ -117,15 +124,15 @@ impl NvApi {
     unsafe fn enum_physical_gpus(&self) -> anyhow::Result<Vec<NvPhysicalGpuHandle>> {
         let f = self.query_interface(QUERY_NVAPI_ENUM_PHYSICAL_GPUS)?;
         let f: unsafe extern "C" fn(
-            handles: &mut [NvPhysicalGpuHandle; NVAPI_MAX_PHYSICAL_GPUS],
+            handles: *mut NvPhysicalGpuHandle,
             count: &mut u32,
         ) -> NvAPI_Status = transmute(f);
 
         let mut count = 0;
         let mut handles =
-            [(ptr::null_mut() as NvPhysicalGpuHandle); NVAPI_MAX_PHYSICAL_GPUS];
+            [ptr::null_mut(); NVAPI_MAX_PHYSICAL_GPUS];
 
-        let status = f(&mut handles, &mut count);
+        let status = f(handles.as_mut_ptr(), &mut count);
         self.handle_status(status)?;
 
         Ok(handles.into_iter().take(count as usize).collect())
@@ -135,12 +142,12 @@ impl NvApi {
         let query_interface = self
             .lib
             .get::<unsafe extern "C" fn(u32) -> *const ()>(QUERY_INTERFACE_FN)
-            .context("Could not get main symbol")?;
+            .context("Could not get nvapi_QueryInterface symbol")?;
 
         let f = query_interface(id);
 
         if f.is_null() {
-            bail!("Got null response for query id {id:x}");
+            bail!("Got null response from nvapi_QueryInterface for query id {id:x}");
         }
 
         Ok(f)
@@ -184,55 +191,31 @@ impl Drop for NvApi {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Default)]
-pub struct NvApiThermalSensor {
-    pub controller: i32,
-    pub default_min: i32,
-    pub default_max: i32,
-    pub current_temp: i32,
-    pub target: i32,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct NvApiThermals {
-    pub version: u32,
-    pub count: u32,
-    pub sensors: [NvApiThermalSensor; 8],
+    version: u32,
+    mask: i32,
+    values: [i32; 40],
 }
 
 impl NvApiThermals {
-    pub fn get_temp(&self, target_id: i32) -> Option<f32> {
-        for i in 0..(self.count as usize).min(8) {
-            if self.sensors[i].target == target_id {
-                let t = self.sensors[i].current_temp;
-                // Standard NVAPI returns degrees Celsius as NvS32.
-                // We check for reasonable values.
-                if t > 0 && t < 150 {
-                    return Some(t as f32);
-                }
-                // Some undocumented implementations might return 8.8 fixed point.
-                if t > 1000 && t < 40000 {
-                    let tf = t as f32 / 256.0;
-                    if tf > 0.0 && tf < 150.0 {
-                        return Some(tf);
-                    }
-                }
-            }
-        }
-        None
+    fn get_value(&self, index: usize) -> Option<f32> {
+        self.values
+            .get(index)
+            .map(|&value| value as f32 / 256.0)
+            .filter(|&value| value > 0.0 && value < 255.0)
     }
 
     pub fn core(&self) -> Option<f32> {
-        self.get_temp(1) // NVAPI_THERMAL_TARGET_GPU
-    }
-
-    pub fn vram(&self) -> Option<f32> {
-        self.get_temp(2) // NVAPI_THERMAL_TARGET_MEMORY
+        self.get_value(0)
     }
 
     pub fn hotspot(&self) -> Option<f32> {
-        self.get_temp(9) // NVAPI_THERMAL_TARGET_HOTSPOT
+        self.get_value(9)
+    }
+
+    pub fn vram(&self) -> Option<f32> {
+        self.get_value(15)
     }
 }
 
@@ -241,6 +224,7 @@ impl NvApiThermals {
 struct NvApiVoltage {
     version: u32,
     flags: u32,
+    padding_1: [u32; 8],
     value_uv: u32,
-    padding: [u32; 16], // Generous padding to match suspected structure size
+    padding_2: [u32; 8],
 }

--- a/daemon/src/nvapi.rs
+++ b/daemon/src/nvapi.rs
@@ -1,0 +1,246 @@
+
+#![allow(clippy::unreadable_literal)]
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+
+use anyhow::{bail, Context};
+use std::{
+    ffi::{c_char, CStr},
+    mem::{self, transmute},
+    ptr,
+};
+
+const LIBRARY_NAME: &str = "libnvidia-api.so.1";
+const QUERY_INTERFACE_FN: &[u8] = b"nvapi_QueryInterface\0";
+
+const QUERY_NVAPI_INITIALIZE: u32 = 0x0150e828;
+const QUERY_NVAPI_UNLOAD: u32 = 0xd22bdd7e;
+const QUERY_NVAPI_ENUM_PHYSICAL_GPUS: u32 = 0xe5ac921f;
+const QUERY_NVAPI_GET_BUS_ID: u32 = 0x1be0b8e5;
+const QUERY_NVAPI_GET_ERROR_MESSAGE: u32 = 0x6c2d048c;
+const QUERY_NVAPI_THERMALS: u32 = 0x65fe3aad; // Undocumented call
+const QUERY_NVAPI_VOLTAGE: u32 = 0x465f9bcf; // Undocumented call
+
+pub type NvAPI_Status = i32;
+pub type NvPhysicalGpuHandle = *mut std::ffi::c_void;
+pub const NVAPI_MAX_PHYSICAL_GPUS: usize = 64;
+pub const NVAPI_SHORT_STRING_MAX: usize = 64;
+
+pub struct NvApi {
+    lib: libloading::Library,
+}
+
+impl NvApi {
+    pub fn new() -> anyhow::Result<Self> {
+        let lib = unsafe {
+            libloading::Library::new(LIBRARY_NAME).context("Could not load nvidia API library")
+        }?;
+
+        let handle = Self { lib };
+
+        unsafe {
+            let initialize = handle.query_interface(QUERY_NVAPI_INITIALIZE)?;
+            let initialize: unsafe extern "C" fn() -> NvAPI_Status = transmute(initialize);
+            let status = initialize();
+            handle.handle_status(status)?;
+        }
+
+        Ok(handle)
+    }
+
+    pub fn find_matching_gpu(&self, bus_id: u32) -> anyhow::Result<Option<NvPhysicalGpuHandle>> {
+        unsafe {
+            let handles = self.enum_physical_gpus()?;
+            for handle in handles {
+                let f = self.query_interface(QUERY_NVAPI_GET_BUS_ID)?;
+                let f: unsafe extern "C" fn(
+                    handle: NvPhysicalGpuHandle,
+                    id: &mut u32,
+                ) -> NvAPI_Status = transmute(f);
+
+                let mut id = 0;
+                let status = f(handle, &mut id);
+                self.handle_status(status)?;
+
+                if id == bus_id {
+                    return Ok(Some(handle));
+                }
+            }
+
+            Ok(None)
+        }
+    }
+
+    pub unsafe fn get_thermals(
+        &self,
+        handle: NvPhysicalGpuHandle,
+    ) -> anyhow::Result<NvApiThermals> {
+        let f = self.query_interface(QUERY_NVAPI_THERMALS)?;
+        let f: unsafe extern "C" fn(
+            handle: NvPhysicalGpuHandle,
+            sensors: &mut NvApiThermals,
+        ) -> NvAPI_Status = transmute(f);
+
+        let mut sensors = NvApiThermals {
+            #[allow(clippy::cast_possible_truncation)]
+            version: (mem::size_of::<NvApiThermals>() | (2 << 16)) as u32,
+            count: 0,
+            sensors: [NvApiThermalSensor::default(); 8],
+        };
+
+        let status = f(handle, &mut sensors);
+        self.handle_status(status)?;
+
+        Ok(sensors)
+    }
+
+    pub unsafe fn get_voltage(&self, handle: NvPhysicalGpuHandle) -> anyhow::Result<u32> {
+        let f = self.query_interface(QUERY_NVAPI_VOLTAGE)?;
+        let f: unsafe extern "C" fn(
+            handle: NvPhysicalGpuHandle,
+            data: &mut NvApiVoltage,
+        ) -> NvAPI_Status = transmute(f);
+
+        let mut data = NvApiVoltage {
+            #[allow(clippy::cast_possible_truncation)]
+            version: (mem::size_of::<NvApiVoltage>() | (1 << 16)) as u32,
+            flags: 0,
+            value_uv: 0,
+            padding: [0; 16],
+        };
+        let status = f(handle, &mut data);
+        self.handle_status(status)?;
+
+        Ok(data.value_uv)
+    }
+
+    unsafe fn enum_physical_gpus(&self) -> anyhow::Result<Vec<NvPhysicalGpuHandle>> {
+        let f = self.query_interface(QUERY_NVAPI_ENUM_PHYSICAL_GPUS)?;
+        let f: unsafe extern "C" fn(
+            handles: &mut [NvPhysicalGpuHandle; NVAPI_MAX_PHYSICAL_GPUS],
+            count: &mut u32,
+        ) -> NvAPI_Status = transmute(f);
+
+        let mut count = 0;
+        let mut handles =
+            [(ptr::null_mut() as NvPhysicalGpuHandle); NVAPI_MAX_PHYSICAL_GPUS];
+
+        let status = f(&mut handles, &mut count);
+        self.handle_status(status)?;
+
+        Ok(handles.into_iter().take(count as usize).collect())
+    }
+
+    unsafe fn query_interface(&self, id: u32) -> anyhow::Result<*const ()> {
+        let query_interface = self
+            .lib
+            .get::<unsafe extern "C" fn(u32) -> *const ()>(QUERY_INTERFACE_FN)
+            .context("Could not get main symbol")?;
+
+        let f = query_interface(id);
+
+        if f.is_null() {
+            bail!("Got null response for query id {id:x}");
+        }
+
+        Ok(f)
+    }
+
+    unsafe fn handle_status(&self, status: NvAPI_Status) -> anyhow::Result<()> {
+        if status == 0 {
+            Ok(())
+        } else {
+            let f = self.query_interface(QUERY_NVAPI_GET_ERROR_MESSAGE)?;
+            let f: unsafe extern "C" fn(
+                status: NvAPI_Status,
+                text: *mut c_char,
+            ) -> NvAPI_Status = transmute(f);
+
+            let mut text = [0 as c_char; NVAPI_SHORT_STRING_MAX];
+            let other_status = f(status, text.as_mut_ptr());
+            if other_status != 0 {
+                bail!(
+                    "Got status {other_status:x} when fetching error message for status {status:x}"
+                );
+            }
+            let text_cstr = CStr::from_ptr(text.as_ptr());
+            bail!(
+                "Got error {status:x} from NvAPI: {}",
+                text_cstr.to_string_lossy()
+            );
+        }
+    }
+}
+
+impl Drop for NvApi {
+    fn drop(&mut self) {
+        unsafe {
+            if let Ok(unload) = self.query_interface(QUERY_NVAPI_UNLOAD) {
+                let unload: unsafe extern "C" fn() -> NvAPI_Status = transmute(unload);
+                unload();
+            }
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+pub struct NvApiThermalSensor {
+    pub controller: i32,
+    pub default_min: i32,
+    pub default_max: i32,
+    pub current_temp: i32,
+    pub target: i32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct NvApiThermals {
+    pub version: u32,
+    pub count: u32,
+    pub sensors: [NvApiThermalSensor; 8],
+}
+
+impl NvApiThermals {
+    pub fn get_temp(&self, target_id: i32) -> Option<f32> {
+        for i in 0..(self.count as usize).min(8) {
+            if self.sensors[i].target == target_id {
+                let t = self.sensors[i].current_temp;
+                // Standard NVAPI returns degrees Celsius as NvS32.
+                // We check for reasonable values.
+                if t > 0 && t < 150 {
+                    return Some(t as f32);
+                }
+                // Some undocumented implementations might return 8.8 fixed point.
+                if t > 1000 && t < 40000 {
+                    let tf = t as f32 / 256.0;
+                    if tf > 0.0 && tf < 150.0 {
+                        return Some(tf);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    pub fn core(&self) -> Option<f32> {
+        self.get_temp(1) // NVAPI_THERMAL_TARGET_GPU
+    }
+
+    pub fn vram(&self) -> Option<f32> {
+        self.get_temp(2) // NVAPI_THERMAL_TARGET_MEMORY
+    }
+
+    pub fn hotspot(&self) -> Option<f32> {
+        self.get_temp(9) // NVAPI_THERMAL_TARGET_HOTSPOT
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+struct NvApiVoltage {
+    version: u32,
+    flags: u32,
+    value_uv: u32,
+    padding: [u32; 16], // Generous padding to match suspected structure size
+}

--- a/daemon/src/nvapi.rs
+++ b/daemon/src/nvapi.rs
@@ -32,7 +32,6 @@ pub struct NvApi {
 
 impl NvApi {
     pub fn new() -> anyhow::Result<Self> {
-        log::debug!("Loading NVIDIA API library: {}", LIBRARY_NAME);
         let lib = unsafe {
             libloading::Library::new(LIBRARY_NAME).context("Could not load nvidia API library")
         }?;
@@ -43,17 +42,15 @@ impl NvApi {
             let initialize = handle.query_interface(QUERY_NVAPI_INITIALIZE)?;
             let initialize: unsafe extern "C" fn() -> NvAPI_Status = transmute(initialize);
             let status = initialize();
-            handle.handle_status(status).context("NvAPI_Initialize failed")?;
+            handle.handle_status(status)?;
         }
 
-        log::debug!("NVIDIA API initialized successfully");
         Ok(handle)
     }
 
     pub fn find_matching_gpu(&self, bus_id: u32) -> anyhow::Result<Option<NvPhysicalGpuHandle>> {
         unsafe {
             let handles = self.enum_physical_gpus()?;
-            log::debug!("Found {} physical GPUs via NVAPI", handles.len());
             for handle in handles {
                 let f = self.query_interface(QUERY_NVAPI_GET_BUS_ID)?;
                 let f: unsafe extern "C" fn(
@@ -65,13 +62,11 @@ impl NvApi {
                 let status = f(handle, &mut id);
                 self.handle_status(status)?;
 
-                log::debug!("GPU handle {:?} has bus ID {}", handle, id);
                 if id == bus_id {
                     return Ok(Some(handle));
                 }
             }
 
-            log::warn!("No GPU matching bus ID {} found in NVAPI", bus_id);
             Ok(None)
         }
     }
@@ -95,7 +90,7 @@ impl NvApi {
         };
 
         let status = f(handle, &mut sensors);
-        self.handle_status(status).context("QUERY_NVAPI_THERMALS failed")?;
+        self.handle_status(status)?;
 
         Ok(sensors)
     }
@@ -116,7 +111,7 @@ impl NvApi {
             padding_2: [0; 8],
         };
         let status = f(handle, &mut data);
-        self.handle_status(status).context("QUERY_NVAPI_VOLTAGE failed")?;
+        self.handle_status(status)?;
 
         Ok(data.value_uv)
     }
@@ -142,12 +137,12 @@ impl NvApi {
         let query_interface = self
             .lib
             .get::<unsafe extern "C" fn(u32) -> *const ()>(QUERY_INTERFACE_FN)
-            .context("Could not get nvapi_QueryInterface symbol")?;
+            .context("Could not get main symbol")?;
 
         let f = query_interface(id);
 
         if f.is_null() {
-            bail!("Got null response from nvapi_QueryInterface for query id {id:x}");
+            bail!("Got null response for query id {id:x}");
         }
 
         Ok(f)
@@ -203,11 +198,7 @@ impl NvApiThermals {
         self.values
             .get(index)
             .map(|&value| value as f32 / 256.0)
-            .filter(|&value| value > 0.0 && value < 255.0)
-    }
-
-    pub fn core(&self) -> Option<f32> {
-        self.get_value(0)
+            .filter(|&value| value > 1.0 && value < 255.0)
     }
 
     pub fn hotspot(&self) -> Option<f32> {
@@ -216,6 +207,10 @@ impl NvApiThermals {
 
     pub fn vram(&self) -> Option<f32> {
         self.get_value(15)
+    }
+
+    pub fn core(&self) -> Option<f32> {
+        self.get_value(0)
     }
 }
 

--- a/gui/src/pages/statistics.rs
+++ b/gui/src/pages/statistics.rs
@@ -387,7 +387,16 @@ fn draw_gpu_info(ui: &mut Ui, state: &AppState) {
                             }
                             
                             if let Some(temp) = gpu.temperature {
-                                ui.label("Temperature:");
+                                ui.label("Core Temperature:");
+                                ui.colored_label(
+                                    temp_color(temp),
+                                    format!("{:.1}°C", temp)
+                                );
+                                ui.end_row();
+                            }
+
+                            if let Some(temp) = gpu.memory_temperature {
+                                ui.label("Memory Temperature:");
                                 ui.colored_label(
                                     temp_color(temp),
                                     format!("{:.1}°C", temp)

--- a/gui/src/pages/statistics.rs
+++ b/gui/src/pages/statistics.rs
@@ -395,6 +395,15 @@ fn draw_gpu_info(ui: &mut Ui, state: &AppState) {
                                 ui.end_row();
                             }
 
+                            if let Some(temp) = gpu.hotspot_temperature {
+                                ui.label("Hotspot Temperature:");
+                                ui.colored_label(
+                                    temp_color(temp),
+                                    format!("{:.1}°C", temp)
+                                );
+                                ui.end_row();
+                            }
+
                             if let Some(temp) = gpu.memory_temperature {
                                 ui.label("Memory Temperature:");
                                 ui.colored_label(


### PR DESCRIPTION
This change adds NVIDIA GPU core voltage, core temperature, and memory temperature to the Statistics page in the LapSphere GUI. It implements the data retrieval in the daemon using undocumented NVAPI calls as requested, with robust fallbacks to NVML for core temperature. The implementation ensures that the GPU is not woken up from a suspended state by checking its power status via sysfs before making API calls.

---
*PR created automatically by Jules for task [3326269886436771732](https://jules.google.com/task/3326269886436771732) started by @weter11*