### PR TITLE
Rework exit handling and settings logic

### DIFF
--- a/daemon/src/dbus_interface.rs
+++ b/daemon/src/dbus_interface.rs
@@ -199,6 +199,11 @@ async fn set_tdp_profile(&self, profile: &str) -> Result<(), zbus::fdo::Error> {
         crate::hardware_control::set_fan_auto(fan_id)
             .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
     }
+
+    async fn set_all_fans_auto(&self) -> Result<(), zbus::fdo::Error> {
+        crate::hardware_control::set_fan_auto(0)
+            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+    }
     
     async fn get_webcam_state(&self) -> Result<bool, zbus::fdo::Error> {
         crate::hardware_control::get_webcam_state()

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -876,7 +876,7 @@ pub fn get_crash_dir() -> String {
     format!("{}/crashes", get_config_dir())
 }
 
-fn load_config_from_disk() -> anyhow::Result<AppConfig> {
+pub fn load_config_from_disk() -> anyhow::Result<AppConfig> {
     let config_dir = get_config_dir();
     let settings_path = format!("{}/settings.json", config_dir);
     let profiles_path = format!("{}/profiles.json", config_dir);

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -194,6 +194,8 @@ pub struct LapSphereApp {
     
     // Keyboard shortcuts
     shortcuts: KeyboardShortcuts,
+
+    startup_frames: u32,
 }
 
 #[derive(Debug)]
@@ -456,6 +458,7 @@ impl LapSphereApp {
             hw_update_tx,
             hw_update_rx,
             shortcuts: KeyboardShortcuts::new(),
+            startup_frames: 10,
         }
     }
     
@@ -693,6 +696,14 @@ impl LapSphereApp {
 
 impl eframe::App for LapSphereApp {
     fn update(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
+        if self.startup_frames > 0 {
+            let start_in_tray = std::env::args().any(|arg| arg == "--tray");
+            if self.state.config.start_minimized || start_in_tray {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
+            }
+            self.startup_frames -= 1;
+        }
+
         // Handle keyboard shortcuts
         self.shortcuts.handle_shortcuts(ctx, &mut self.state);
         
@@ -749,11 +760,14 @@ impl eframe::App for LapSphereApp {
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
         if let Some(client) = &self.dbus_client {
             let client = client.clone();
-            let rt = tokio::runtime::Handle::current();
-            let _ = rt.block_on(async move {
-                let _ = tokio::time::timeout(Duration::from_secs(2), client.set_all_fans_auto()).await;
-                let _ = tokio::time::timeout(Duration::from_secs(2), client.shutdown_daemon()).await;
-            });
+            // Use a fresh runtime for shutdown to avoid potential nesting issues
+            // and ensure commands are processed before the main runtime closes.
+            if let Ok(rt) = tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                let _ = rt.block_on(async move {
+                    let _ = tokio::time::timeout(Duration::from_secs(2), client.set_all_fans_auto()).await;
+                    let _ = tokio::time::timeout(Duration::from_secs(2), client.shutdown_daemon()).await;
+                });
+            }
         }
     }
 }
@@ -907,6 +921,10 @@ pub fn load_config_from_disk() -> anyhow::Result<AppConfig> {
     }
     if let Some(profiles) = profiles {
         profiles.apply_to(&mut config);
+    }
+
+    if config.start_minimized {
+        config.tray_enabled = true;
     }
 
     config.statistics_sections.section_order =

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -749,8 +749,9 @@ impl eframe::App for LapSphereApp {
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
         if let Some(client) = &self.dbus_client {
             let client = client.clone();
-            tokio::spawn(async move {
-                let _ = tokio::time::timeout(Duration::from_secs(2), client.set_fan_auto(0)).await;
+            let rt = tokio::runtime::Handle::current();
+            let _ = rt.block_on(async move {
+                let _ = tokio::time::timeout(Duration::from_secs(2), client.set_all_fans_auto()).await;
                 let _ = tokio::time::timeout(Duration::from_secs(2), client.shutdown_daemon()).await;
             });
         }
@@ -950,8 +951,20 @@ fn save_settings_to_disk(config: &AppConfig) -> anyhow::Result<()> {
                 X-GNOME-Autostart-enabled=true\n"
             );
             std::fs::write(&desktop_file, content)?;
-        } else if std::path::Path::new(&desktop_file).exists() {
-            std::fs::remove_file(&desktop_file)?;
+        } else {
+            // Write a desktop file that explicitly disables autostart to override system-wide one
+            std::fs::create_dir_all(&autostart_dir)?;
+            let content = format!(
+                "[Desktop Entry]\n\
+                Type=Application\n\
+                Name=LapSphere\n\
+                Exec=lapsphere --tray\n\
+                Icon=lapsphere\n\
+                X-GNOME-Autostart-enabled=false\n\
+                NoDisplay=true\n\
+                Hidden=true\n"
+            );
+            std::fs::write(&desktop_file, content)?;
         }
     }
 

--- a/gui/src/dbus_client.rs
+++ b/gui/src/dbus_client.rs
@@ -29,7 +29,6 @@ pub enum DbusCommand {
     GetBatteryAvailableStartThresholds { reply: oneshot::Sender<Result<Vec<u8>>> },
     GetBatteryAvailableEndThresholds { reply: oneshot::Sender<Result<Vec<u8>>> },
     SetBatterySettings { settings: BatterySettings, reply: oneshot::Sender<Result<()>> },
-    SetFanAuto { fan_id: u32, reply: oneshot::Sender<Result<()>> },
     SetAllFansAuto { reply: oneshot::Sender<Result<()>> },
     SetGpuLockedClocks { device_index: u32, min_clock: u32, max_clock: u32, reply: oneshot::Sender<Result<()>> },
     ResetGpuClocks { device_index: u32, reply: oneshot::Sender<Result<()>> },
@@ -182,12 +181,6 @@ impl DbusClient {
     pub fn set_battery_settings(&self, settings: BatterySettings) -> oneshot::Receiver<Result<()>> {
         let (tx, rx) = oneshot::channel();
         let _ = self.command_tx.send(DbusCommand::SetBatterySettings { settings, reply: tx });
-        rx
-    }
-
-    pub fn set_fan_auto(&self, fan_id: u32) -> oneshot::Receiver<Result<()>> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self.command_tx.send(DbusCommand::SetFanAuto { fan_id, reply: tx });
         rx
     }
 
@@ -425,12 +418,6 @@ async fn dbus_worker(mut command_rx: mpsc::UnboundedReceiver<DbusCommand>) -> Re
                 }
                 DbusCommand::SetBatterySettings { settings, reply } => {
                     let result = set_battery_settings_impl(&connection, settings).await;
-                    let is_err = result.is_err();
-                    let _ = reply.send(result);
-                    if is_err { Err(anyhow::anyhow!("DBus call failed")) } else { Ok(()) }
-                }
-                DbusCommand::SetFanAuto { fan_id, reply } => {
-                    let result = set_fan_auto_impl(&connection, fan_id).await;
                     let is_err = result.is_err();
                     let _ = reply.send(result);
                     if is_err { Err(anyhow::anyhow!("DBus call failed")) } else { Ok(()) }
@@ -795,17 +782,6 @@ async fn set_battery_settings_impl(conn: &Connection, settings: BatterySettings)
 
     let json = serde_json::to_string(&settings)?;
     proxy.call::<_, _, ()>("SetBatterySettings", &(json.as_str(),)).await?;
-    Ok(())
-}
-
-async fn set_fan_auto_impl(conn: &Connection, fan_id: u32) -> Result<()> {
-    let proxy = zbus::Proxy::new(
-        conn,
-        "io.lapsphere.Control",
-        "/io/lapsphere/Control",
-        "io.lapsphere.Control",
-    ).await?;
-    proxy.call::<_, _, ()>("SetFanAuto", &(fan_id,)).await?;
     Ok(())
 }
 

--- a/gui/src/dbus_client.rs
+++ b/gui/src/dbus_client.rs
@@ -30,6 +30,7 @@ pub enum DbusCommand {
     GetBatteryAvailableEndThresholds { reply: oneshot::Sender<Result<Vec<u8>>> },
     SetBatterySettings { settings: BatterySettings, reply: oneshot::Sender<Result<()>> },
     SetFanAuto { fan_id: u32, reply: oneshot::Sender<Result<()>> },
+    SetAllFansAuto { reply: oneshot::Sender<Result<()>> },
     SetGpuLockedClocks { device_index: u32, min_clock: u32, max_clock: u32, reply: oneshot::Sender<Result<()>> },
     ResetGpuClocks { device_index: u32, reply: oneshot::Sender<Result<()>> },
     GetGpuClockRanges { device_index: u32, reply: oneshot::Sender<Result<(u32, u32)>> },
@@ -187,6 +188,12 @@ impl DbusClient {
     pub fn set_fan_auto(&self, fan_id: u32) -> oneshot::Receiver<Result<()>> {
         let (tx, rx) = oneshot::channel();
         let _ = self.command_tx.send(DbusCommand::SetFanAuto { fan_id, reply: tx });
+        rx
+    }
+
+    pub fn set_all_fans_auto(&self) -> oneshot::Receiver<Result<()>> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.command_tx.send(DbusCommand::SetAllFansAuto { reply: tx });
         rx
     }
 
@@ -424,6 +431,12 @@ async fn dbus_worker(mut command_rx: mpsc::UnboundedReceiver<DbusCommand>) -> Re
                 }
                 DbusCommand::SetFanAuto { fan_id, reply } => {
                     let result = set_fan_auto_impl(&connection, fan_id).await;
+                    let is_err = result.is_err();
+                    let _ = reply.send(result);
+                    if is_err { Err(anyhow::anyhow!("DBus call failed")) } else { Ok(()) }
+                }
+                DbusCommand::SetAllFansAuto { reply } => {
+                    let result = set_all_fans_auto_impl(&connection).await;
                     let is_err = result.is_err();
                     let _ = reply.send(result);
                     if is_err { Err(anyhow::anyhow!("DBus call failed")) } else { Ok(()) }
@@ -793,6 +806,17 @@ async fn set_fan_auto_impl(conn: &Connection, fan_id: u32) -> Result<()> {
         "io.lapsphere.Control",
     ).await?;
     proxy.call::<_, _, ()>("SetFanAuto", &(fan_id,)).await?;
+    Ok(())
+}
+
+async fn set_all_fans_auto_impl(conn: &Connection) -> Result<()> {
+    let proxy = zbus::Proxy::new(
+        conn,
+        "io.lapsphere.Control",
+        "/io/lapsphere/Control",
+        "io.lapsphere.Control",
+    ).await?;
+    proxy.call::<_, _, ()>("SetAllFansAuto", &()).await?;
     Ok(())
 }
 

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -120,7 +120,10 @@ fn main() -> Result<(), eframe::Error> {
     setup_panic_hook();
 
     let args: Vec<String> = std::env::args().collect();
-    let start_in_tray = args.contains(&"--tray".to_string());
+    let start_in_tray_arg = args.contains(&"--tray".to_string());
+
+    let config = app::load_config_from_disk().unwrap_or_default();
+    let start_minimized = start_in_tray_arg || config.start_minimized;
 
     // Create and enter a Tokio runtime context.
     // This is required for `tokio::spawn` to work in the `DbusClient`.
@@ -144,7 +147,7 @@ fn main() -> Result<(), eframe::Error> {
             .with_inner_size([570.0, 620.0])
             .with_min_inner_size([440.0, 470.0])
             .with_icon(load_icon())
-            .with_visible(!start_in_tray),
+            .with_visible(!start_minimized),
         ..Default::default()
     };
     

--- a/gui/src/pages/settings.rs
+++ b/gui/src/pages/settings.rs
@@ -295,6 +295,9 @@ fn draw_main_settings(ui: &mut Ui, state: &mut AppState, theme: &mut LapSphereTh
     ui.add_space(6.0);
     
     if ui.checkbox(&mut state.config.start_minimized, "Start minimized").changed() {
+        if state.config.start_minimized {
+            state.config.tray_enabled = true;
+        }
         let _ = state.save_settings();
     }
 


### PR DESCRIPTION
This rework addresses three main issues:
1. Application exit now correctly resets fans to auto and shuts down the daemon by using a blocking runtime call in `on_exit`, ensuring commands are sent before process termination.
2. The autostart feature is fixed to correctly override system-wide desktop files in `/etc/xdg/autostart` by creating a user-local desktop file with `X-GNOME-Autostart-enabled=false` when disabled.
3. The "Start minimized" setting now automatically enables the system tray icon to ensure the app is reachable after starting hidden.

---
*PR created automatically by Jules for task [806356796098832204](https://jules.google.com/task/806356796098832204) started by @weter11*