### PR TITLE
Fix empty logs and add VRAM info

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -13,6 +13,7 @@ pub struct SystemInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogEntry {
     pub level: String,
+    pub target: String,
     pub message: String,
     pub timestamp: String,
 }

--- a/daemon/src/dbus_interface.rs
+++ b/daemon/src/dbus_interface.rs
@@ -6,77 +6,113 @@ use nix::sys::signal::{raise, Signal};
 
 const SHUTDOWN_SIGNAL_DELAY_MS: u64 = 200;
 
+macro_rules! log_api {
+    ($method:expr, $call:expr, $ok_msg:expr) => {{
+        log::info!(target: "api.call", "{}", $method);
+        let start = std::time::Instant::now();
+        let res = $call;
+        let duration = start.elapsed().as_millis();
+        match &res {
+            Ok(val) => log::info!(target: "api.ok", "{} {} duration_ms={}", $method, $ok_msg(val), duration),
+            Err(e) => log::warn!(target: "api.fail", "{} reason=\"{}\" duration_ms={}", $method, e, duration),
+        }
+        res.map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+    }};
+}
+
+macro_rules! log_api_json {
+    ($method:expr, $call:expr, $ok_msg:expr) => {{
+        log::info!(target: "api.call", "{}", $method);
+        let start = std::time::Instant::now();
+        let res = $call;
+        let duration = start.elapsed().as_millis();
+        match res {
+            Ok(info) => {
+                log::info!(target: "api.ok", "{} {} duration_ms={}", $method, $ok_msg(&info), duration);
+                serde_json::to_string(&info).map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+            }
+            Err(e) => {
+                log::warn!(target: "api.fail", "{} reason=\"{}\" duration_ms={}", $method, e, duration);
+                Err(zbus::fdo::Error::Failed(e.to_string()))
+            }
+        }
+    }};
+}
+
 pub struct ControlInterface;
 
 #[interface(name = "io.lapsphere.Control")]
 impl ControlInterface {
     async fn get_system_info(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_system_info() {
-            Ok(info) => serde_json::to_string(&info)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetSystemInfo",
+            crate::hardware_detection::get_system_info(),
+            |i: &SystemInfo| format!("model=\"{}\"", i.product_name)
+        )
     }
 
     async fn get_memory_info(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_memory_info() {
-            Ok(info) => serde_json::to_string(&info)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetMemoryInfo",
+            crate::hardware_detection::get_memory_info(),
+            |i: &MemoryInfo| format!("total_gib={:.1} used_percent={:.1}", i.total_gib, i.used_percent)
+        )
     }
 
     async fn get_cpu_info(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_cpu_info() {
-            Ok(info) => serde_json::to_string(&info)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetCpuInfo",
+            crate::hardware_detection::get_cpu_info(),
+            |i: &CpuInfo| format!("model=\"{}\" cores={}", i.name, i.physical_cores)
+        )
     }
 
     async fn get_gpu_info(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_gpu_info() {
-            Ok(info) => serde_json::to_string(&info)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetGpuInfo",
+            crate::hardware_detection::get_gpu_info(),
+            |i: &Vec<GpuInfo>| format!("count={}", i.len())
+        )
     }
 
     async fn get_battery_info(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_battery_info() {
-            Ok(info) => serde_json::to_string(&info)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetBatteryInfo",
+            crate::hardware_detection::get_battery_info(),
+            |i: &BatteryInfo| format!("percent={} status=\"{}\"", i.charge_percent, i.status)
+        )
     }
 
     async fn get_storage_device_info(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_storage_device_info() {
-            Ok(info) => serde_json::to_string(&info)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetStorageDeviceInfo",
+            crate::hardware_detection::get_storage_device_info(),
+            |i: &Vec<StorageDevice>| format!("count={}", i.len())
+        )
     }
 
     async fn get_mount_info(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_mount_info() {
-            Ok(info) => serde_json::to_string(&info)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetMountInfo",
+            crate::hardware_detection::get_mount_info(),
+            |i: &Vec<MountInfo>| format!("count={}", i.len())
+        )
     }
 
     async fn get_wifi_info(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_wifi_info() {
-            Ok(info) => serde_json::to_string(&info)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetWifiInfo",
+            crate::hardware_detection::get_wifi_info(),
+            |i: &Vec<WiFiInfo>| format!("interfaces={}", i.len())
+        )
     }
 
     async fn set_cpu_governor(&self, governor: &str) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_cpu_governor(governor)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetCpuGovernor",
+            crate::hardware_control::set_cpu_governor(governor),
+            |_| format!("governor=\"{}\"", governor)
+        )
     }
 
     async fn set_cpu_frequency_limits(
@@ -84,128 +120,177 @@ impl ControlInterface {
         min_freq: u64,
         max_freq: u64,
     ) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_cpu_frequency_limits(min_freq, max_freq)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetCpuFrequencyLimits",
+            crate::hardware_control::set_cpu_frequency_limits(min_freq, max_freq),
+            |_| format!("min={} max={}", min_freq, max_freq)
+        )
     }
 
     async fn set_cpu_boost(&self, enabled: bool) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_cpu_boost(enabled)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetCpuBoost",
+            crate::hardware_control::set_cpu_boost(enabled),
+            |_| format!("enabled={}", enabled)
+        )
     }
 
     async fn set_smt(&self, enabled: bool) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_smt(enabled)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetSmt",
+            crate::hardware_control::set_smt(enabled),
+            |_| format!("enabled={}", enabled)
+        )
     }
 
     async fn set_amd_pstate_status(&self, status: &str) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_amd_pstate_status(status)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetAmdPstateStatus",
+            crate::hardware_control::set_amd_pstate_status(status),
+            |_| format!("status=\"{}\"", status)
+        )
     }
 
     async fn set_intel_pstate_status(&self, status: &str) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_intel_pstate_status(status)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetIntelPstateStatus",
+            crate::hardware_control::set_intel_pstate_status(status),
+            |_| format!("status=\"{}\"", status)
+        )
     }
 
     async fn apply_profile(&self, profile_json: &str) -> Result<(), zbus::fdo::Error> {
-        let profile: Profile = serde_json::from_str(profile_json)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
+        log::info!(target: "api.call", "ApplyProfile");
+        let start = std::time::Instant::now();
+        let res = (|| async {
+            let profile: Profile = serde_json::from_str(profile_json)?;
+            // Update GPU daemon state for dynamic overclocking
+            {
+                let mut state = crate::GPU_DAEMON_STATE.lock().unwrap();
+                *state = Some(profile.gpu_settings.clone());
+            }
+            crate::hardware_control::apply_profile(&profile)
+        })().await;
 
-        // Update GPU daemon state for dynamic overclocking
-        {
-            let mut state = crate::GPU_DAEMON_STATE.lock().unwrap();
-            *state = Some(profile.gpu_settings.clone());
+        let duration = start.elapsed().as_millis();
+        match &res {
+            Ok(_) => log::info!(target: "api.ok", "ApplyProfile duration_ms={}", duration),
+            Err(e) => log::warn!(target: "api.fail", "ApplyProfile reason=\"{}\" duration_ms={}", e, duration),
         }
-
-        crate::hardware_control::apply_profile(&profile)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        res.map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
     }
 
     async fn get_tdp_profiles(&self) -> Result<String, zbus::fdo::Error> {
-    match crate::hardware_detection::get_tdp_profiles() {
-        Ok(profiles) => serde_json::to_string(&profiles)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-        Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
+        log_api_json!(
+            "GetTdpProfiles",
+            crate::hardware_detection::get_tdp_profiles(),
+            |i: &Vec<String>| format!("count={}", i.len())
+        )
     }
-}
 
     async fn get_current_tdp_profile(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_current_tdp_profile() {
-            Ok(profile) => Ok(profile),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api!(
+            "GetCurrentTdpProfile",
+            crate::hardware_detection::get_current_tdp_profile(),
+            |i: &String| format!("profile=\"{}\"", i)
+        )
     }
 
-async fn set_tdp_profile(&self, profile: &str) -> Result<(), zbus::fdo::Error> {
-    crate::hardware_control::set_tdp_profile(profile)
-        .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
-}
+    async fn set_tdp_profile(&self, profile: &str) -> Result<(), zbus::fdo::Error> {
+        log_api!(
+            "SetTdpProfile",
+            crate::hardware_control::set_tdp_profile(profile),
+            |_| format!("profile=\"{}\"", profile)
+        )
+    }
 
     async fn get_fan_speeds(&self) -> Result<String, zbus::fdo::Error> {
-    match crate::hardware_detection::get_fan_speeds() {
-        Ok(fans) => serde_json::to_string(&fans)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-        Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
+        log_api_json!(
+            "GetFanSpeeds",
+            crate::hardware_detection::get_fan_speeds(),
+            |i: &Vec<(u32, u32)>| format!("count={}", i.len())
+        )
     }
-}
 
     async fn get_fan_info(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_all_fan_info() {
-            Ok(info) => serde_json::to_string(&info)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetFanInfo",
+            crate::hardware_detection::get_all_fan_info(),
+            |i: &Vec<FanInfo>| format!("count={}", i.len())
+        )
     }
 
     async fn get_fan_temperature(&self, fan_id: u32) -> Result<u32, zbus::fdo::Error> {
-        if !crate::tuxedo_io::TuxedoIo::is_available() {
-            return Err(zbus::fdo::Error::Failed("tuxedo_io not available".to_string()));
-        }
-        
-        match crate::tuxedo_io::TuxedoIo::new() {
-            Ok(io) => io.get_fan_temperature(fan_id)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api!(
+            "GetFanTemperature",
+            (|| {
+                if !crate::tuxedo_io::TuxedoIo::is_available() {
+                    return Err(anyhow::anyhow!("tuxedo_io not available"));
+                }
+                crate::tuxedo_io::TuxedoIo::new()?.get_fan_temperature(fan_id)
+            })(),
+            |i: &u32| format!("id={} temp={}C", fan_id, i)
+        )
     }
     
     async fn set_fan_speed(&self, fan_id: u32, speed: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_fan_speed(fan_id, speed)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetFanSpeed",
+            crate::hardware_control::set_fan_speed(fan_id, speed),
+            |_| format!("id={} speed={}", fan_id, speed)
+        )
     }
     
     async fn set_fan_auto(&self, fan_id: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_fan_auto(fan_id)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetFanAuto",
+            crate::hardware_control::set_fan_auto(fan_id),
+            |_| format!("id={}", fan_id)
+        )
     }
 
     async fn set_all_fans_auto(&self) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_fan_auto(0)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetAllFansAuto",
+            crate::hardware_control::set_fan_auto(0),
+            |_| "".to_string()
+        )
     }
 
     async fn set_gpu_fan_speed(&self, device_index: u32, fan_index: u32, speed: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_gpu_fan_speed(device_index, fan_index, speed)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetGpuFanSpeed",
+            crate::hardware_control::set_gpu_fan_speed(device_index, fan_index, speed),
+            |_| format!("gpu={} fan={} speed={}", device_index, fan_index, speed)
+        )
     }
 
     async fn set_gpu_fan_auto(&self, device_index: u32, fan_index: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_gpu_fan_auto(device_index, fan_index)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetGpuFanAuto",
+            crate::hardware_control::set_gpu_fan_auto(device_index, fan_index),
+            |_| format!("gpu={} fan={}", device_index, fan_index)
+        )
     }
     
     async fn get_webcam_state(&self) -> Result<bool, zbus::fdo::Error> {
-        crate::hardware_control::get_webcam_state()
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "GetWebcamState",
+            crate::hardware_control::get_webcam_state(),
+            |i: &bool| format!("enabled={}", i)
+        )
     }
     
     async fn set_webcam_state(&self, enabled: bool) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_webcam_state(enabled)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetWebcamState",
+            crate::hardware_control::set_webcam_state(enabled),
+            |_| format!("enabled={}", enabled)
+        )
     }
 
     async fn get_daemon_logs(&self) -> Result<String, zbus::fdo::Error> {
+        // No explicit API logging for logs retrieval to avoid recursion and noise
         let logs = crate::DAEMON_LOGS.lock().unwrap();
         let logs_vec: Vec<LogEntry> = logs.iter().cloned().collect();
         serde_json::to_string(&logs_vec)
@@ -214,84 +299,93 @@ async fn set_tdp_profile(&self, profile: &str) -> Result<(), zbus::fdo::Error> {
     
     // Battery charge control methods
     async fn get_battery_charge_type(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::battery_control::BatteryControl::new() {
-            Ok(battery) => battery.get_charge_type()
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api!(
+            "GetBatteryChargeType",
+            (|| {
+                crate::battery_control::BatteryControl::new()?.get_charge_type()
+            })(),
+            |i: &String| format!("type=\"{}\"", i)
+        )
     }
     
     async fn set_battery_charge_type(&self, charge_type: &str) -> Result<(), zbus::fdo::Error> {
-        match crate::battery_control::BatteryControl::new() {
-            Ok(battery) => battery.set_charge_type(charge_type)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api!(
+            "SetBatteryChargeType",
+            (|| {
+                crate::battery_control::BatteryControl::new()?.set_charge_type(charge_type)
+            })(),
+            |_| format!("type=\"{}\"", charge_type)
+        )
     }
     
     async fn get_battery_charge_start_threshold(&self) -> Result<u8, zbus::fdo::Error> {
-        match crate::battery_control::BatteryControl::new() {
-            Ok(battery) => battery.get_charge_control_start_threshold()
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api!(
+            "GetBatteryChargeStartThreshold",
+            (|| {
+                crate::battery_control::BatteryControl::new()?.get_charge_control_start_threshold()
+            })(),
+            |i: &u8| format!("threshold={}", i)
+        )
     }
     
     async fn set_battery_charge_start_threshold(&self, threshold: u8) -> Result<(), zbus::fdo::Error> {
-        match crate::battery_control::BatteryControl::new() {
-            Ok(battery) => battery.set_charge_control_start_threshold(threshold)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api!(
+            "SetBatteryChargeStartThreshold",
+            (|| {
+                crate::battery_control::BatteryControl::new()?.set_charge_control_start_threshold(threshold)
+            })(),
+            |_| format!("threshold={}", threshold)
+        )
     }
     
     async fn get_battery_charge_end_threshold(&self) -> Result<u8, zbus::fdo::Error> {
-        match crate::battery_control::BatteryControl::new() {
-            Ok(battery) => battery.get_charge_control_end_threshold()
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api!(
+            "GetBatteryChargeEndThreshold",
+            (|| {
+                crate::battery_control::BatteryControl::new()?.get_charge_control_end_threshold()
+            })(),
+            |i: &u8| format!("threshold={}", i)
+        )
     }
     
     async fn set_battery_charge_end_threshold(&self, threshold: u8) -> Result<(), zbus::fdo::Error> {
-        match crate::battery_control::BatteryControl::new() {
-            Ok(battery) => battery.set_charge_control_end_threshold(threshold)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api!(
+            "SetBatteryChargeEndThreshold",
+            (|| {
+                crate::battery_control::BatteryControl::new()?.set_charge_control_end_threshold(threshold)
+            })(),
+            |_| format!("threshold={}", threshold)
+        )
     }
     
     async fn get_battery_available_start_thresholds(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::battery_control::BatteryControl::new() {
-            Ok(battery) => {
-                let thresholds = battery.get_available_start_thresholds()
-                    .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
-                serde_json::to_string(&thresholds)
-                    .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
-            }
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetBatteryAvailableStartThresholds",
+            (|| {
+                crate::battery_control::BatteryControl::new()?.get_available_start_thresholds()
+            })(),
+            |i: &Vec<u8>| format!("count={}", i.len())
+        )
     }
     
     async fn get_battery_available_end_thresholds(&self) -> Result<String, zbus::fdo::Error> {
-        match crate::battery_control::BatteryControl::new() {
-            Ok(battery) => {
-                let thresholds = battery.get_available_end_thresholds()
-                    .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
-                serde_json::to_string(&thresholds)
-                    .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
-            }
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetBatteryAvailableEndThresholds",
+            (|| {
+                crate::battery_control::BatteryControl::new()?.get_available_end_thresholds()
+            })(),
+            |i: &Vec<u8>| format!("count={}", i.len())
+        )
     }
     
     async fn get_hardware_interface_info(&self) -> Result<String, zbus::fdo::Error> {
-        if !crate::tuxedo_io::TuxedoIo::is_available() {
-            return Ok("None".to_string());
-        }
-        
-        match crate::tuxedo_io::TuxedoIo::new() {
-            Ok(io) => {
+        log_api!(
+            "GetHardwareInterfaceInfo",
+            (|| -> Result<String> {
+                if !crate::tuxedo_io::TuxedoIo::is_available() {
+                    return Ok("None".to_string());
+                }
+                let io = crate::tuxedo_io::TuxedoIo::new()?;
                 let interface = match io.get_interface() {
                     crate::tuxedo_io::HardwareInterface::Clevo => "Clevo",
                     crate::tuxedo_io::HardwareInterface::Uniwill => "Uniwill",
@@ -299,107 +393,153 @@ async fn set_tdp_profile(&self, profile: &str) -> Result<(), zbus::fdo::Error> {
                 };
                 let fan_count = io.get_fan_count();
                 Ok(format!("Interface: {}, Fans: {}", interface, fan_count))
-            }
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+            })(),
+            |i: &String| i.clone()
+        )
     }
 
     async fn get_keyboard_capabilities(&self) -> Result<String, zbus::fdo::Error> {
-        let caps = crate::hardware_detection::get_keyboard_capabilities();
-        serde_json::to_string(&caps)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api_json!(
+            "GetKeyboardCapabilities",
+            Ok::<_, anyhow::Error>(crate::hardware_detection::get_keyboard_capabilities()),
+            |i: &KeyboardCapabilities| format!("type={:?} zones={}", i.keyboard_type, i.num_zones)
+        )
     }
     
     // Keyboard preview - apply keyboard settings immediately without saving to profile
     async fn preview_keyboard_settings(&self, settings_json: &str) -> Result<(), zbus::fdo::Error> {
-        let settings: KeyboardSettings = serde_json::from_str(settings_json)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
-        crate::hardware_control::preview_keyboard_settings(&settings)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "PreviewKeyboardSettings",
+            (|| {
+                let settings: KeyboardSettings = serde_json::from_str(settings_json)?;
+                crate::hardware_control::preview_keyboard_settings(&settings)
+            })(),
+            |_| "".to_string()
+        )
     }
 
     async fn set_battery_settings(&self, settings_json: &str) -> Result<(), zbus::fdo::Error> {
-        let settings: BatterySettings = serde_json::from_str(settings_json)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))?;
-        crate::hardware_control::apply_battery_settings(&settings)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetBatterySettings",
+            (|| {
+                let settings: BatterySettings = serde_json::from_str(settings_json)?;
+                crate::hardware_control::apply_battery_settings(&settings)
+            })(),
+            |_| "".to_string()
+        )
     }
 
     async fn set_gpu_locked_clocks(&self, device_index: u32, min_clock: u32, max_clock: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_gpu_locked_clocks(device_index, min_clock, max_clock)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetGpuLockedClocks",
+            crate::hardware_control::set_gpu_locked_clocks(device_index, min_clock, max_clock),
+            |_| format!("gpu={} min={} max={}", device_index, min_clock, max_clock)
+        )
     }
 
     async fn set_memory_locked_clocks(&self, device_index: u32, min_clock: u32, max_clock: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_memory_locked_clocks(device_index, min_clock, max_clock)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetMemoryLockedClocks",
+            crate::hardware_control::set_memory_locked_clocks(device_index, min_clock, max_clock),
+            |_| format!("gpu={} min={} max={}", device_index, min_clock, max_clock)
+        )
     }
 
     async fn reset_memory_locked_clocks(&self, device_index: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::reset_memory_locked_clocks(device_index)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "ResetMemoryLockedClocks",
+            crate::hardware_control::reset_memory_locked_clocks(device_index),
+            |_| format!("gpu={}", device_index)
+        )
     }
 
     async fn reset_gpu_clocks(&self, device_index: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::reset_gpu_clocks(device_index)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "ResetGpuClocks",
+            crate::hardware_control::reset_gpu_clocks(device_index),
+            |_| format!("gpu={}", device_index)
+        )
     }
 
     async fn get_gpu_clock_ranges(&self, device_index: u32) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_gpu_clock_ranges(device_index) {
-            Ok(ranges) => serde_json::to_string(&ranges)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetGpuClockRanges",
+            crate::hardware_detection::get_gpu_clock_ranges(device_index),
+            |i: &(u32, u32)| format!("gpu={} range={}..{}", device_index, i.0, i.1)
+        )
     }
 
     async fn get_gpu_mem_clock_ranges(&self, device_index: u32) -> Result<String, zbus::fdo::Error> {
-        match crate::hardware_detection::get_gpu_mem_clock_ranges(device_index) {
-            Ok(ranges) => serde_json::to_string(&ranges)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string())),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        log_api_json!(
+            "GetGpuMemClockRanges",
+            crate::hardware_detection::get_gpu_mem_clock_ranges(device_index),
+            |i: &Vec<u32>| format!("gpu={} count={}", device_index, i.len())
+        )
     }
 
     async fn set_gpu_core_offset(&self, device_index: u32, offset: f32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_gpu_core_offset(device_index, offset)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetGpuCoreOffset",
+            crate::hardware_control::set_gpu_core_offset(device_index, offset),
+            |_| format!("gpu={} offset={}", device_index, offset)
+        )
     }
 
     async fn set_gpu_memory_offset(&self, device_index: u32, offset: f32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_gpu_memory_offset(device_index, offset)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetGpuMemoryOffset",
+            crate::hardware_control::set_gpu_memory_offset(device_index, offset),
+            |_| format!("gpu={} offset={}", device_index, offset)
+        )
     }
 
     async fn set_gpu_power_limit(&self, device_index: u32, limit_watts: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_gpu_power_limit(device_index, limit_watts)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetGpuPowerLimit",
+            crate::hardware_control::set_gpu_power_limit(device_index, limit_watts),
+            |_| format!("gpu={} limit={}W", device_index, limit_watts)
+        )
     }
 
     async fn get_gpu_core_offset_limits(&self, device_index: u32) -> Result<(i32, i32), zbus::fdo::Error> {
-        crate::hardware_detection::get_gpu_core_offset_limits(device_index)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "GetGpuCoreOffsetLimits",
+            crate::hardware_detection::get_gpu_core_offset_limits(device_index),
+            |i: &(i32, i32)| format!("gpu={} limits={}..{}", device_index, i.0, i.1)
+        )
     }
 
     async fn get_gpu_memory_offset_limits(&self, device_index: u32) -> Result<(i32, i32), zbus::fdo::Error> {
-        crate::hardware_detection::get_gpu_memory_offset_limits(device_index)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "GetGpuMemoryOffsetLimits",
+            crate::hardware_detection::get_gpu_memory_offset_limits(device_index),
+            |i: &(i32, i32)| format!("gpu={} limits={}..{}", device_index, i.0, i.1)
+        )
     }
 
     async fn set_prime_profile(&self, profile: &str) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_control::set_prime_profile(profile)
-            .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
+        log_api!(
+            "SetPrimeProfile",
+            crate::hardware_control::set_prime_profile(profile),
+            |_| format!("profile=\"{}\"", profile)
+        )
     }
 
     // Polling scheduler methods
     async fn update_polling_interval(&self, component: &str, interval_ms: u64) -> Result<(), zbus::fdo::Error> {
-        if let Some(handle) = crate::SCHEDULER_HANDLE.get() {
-            let interval = std::time::Duration::from_millis(interval_ms);
-            handle.update_interval(component.to_string(), interval)
-                .map_err(|e| zbus::fdo::Error::Failed(e.to_string()))
-        } else {
-            Err(zbus::fdo::Error::Failed("Scheduler not initialized".to_string()))
-        }
+        log_api!(
+            "UpdatePollingInterval",
+            (|| {
+                if let Some(handle) = crate::SCHEDULER_HANDLE.get() {
+                    let interval = std::time::Duration::from_millis(interval_ms);
+                    handle.update_interval(component.to_string(), interval)
+                        .map_err(|e| anyhow::anyhow!(e))
+                } else {
+                    Err(anyhow::anyhow!("Scheduler not initialized"))
+                }
+            })(),
+            |_| format!("component=\"{}\" interval_ms={}", component, interval_ms)
+        )
     }
 
     async fn shutdown_daemon(&self) -> Result<(), zbus::fdo::Error> {

--- a/daemon/src/hardware_control.rs
+++ b/daemon/src/hardware_control.rs
@@ -24,7 +24,7 @@ pub fn set_cpu_governor(governor: &str) -> Result<()> {
             .map_err(|e| anyhow!("Failed to set governor for CPU {}: {}", i, e))?;
     }
     
-    log::info!("Set CPU governor to: {}", governor);
+    log::info!(target: "hw.cpu", "set_governor profile=\"{}\"", governor);
     Ok(())
 }
 
@@ -66,7 +66,7 @@ pub fn set_cpu_frequency_limits(min_freq: u64, max_freq: u64) -> Result<()> {
         }
     }
     
-    log::info!("Set CPU frequency limits: {} - {} kHz", min_freq, max_freq);
+    log::info!(target: "hw.cpu", "set_freq_limits min={} max={}", min_freq, max_freq);
     Ok(())
 }
 
@@ -75,7 +75,7 @@ pub fn set_cpu_boost(enabled: bool) -> Result<()> {
     let amd_path = "/sys/devices/system/cpu/cpufreq/boost";
     if Path::new(amd_path).exists() {
         fs::write(amd_path, if enabled { "1" } else { "0" })?;
-        log::info!("Set AMD CPU boost to: {}", enabled);
+        log::info!(target: "hw.cpu", "set_amd_boost enabled={}", enabled);
         return Ok(());
     }
     
@@ -83,7 +83,7 @@ pub fn set_cpu_boost(enabled: bool) -> Result<()> {
     let intel_path = "/sys/devices/system/cpu/intel_pstate/no_turbo";
     if Path::new(intel_path).exists() {
         fs::write(intel_path, if enabled { "0" } else { "1" })?;
-        log::info!("Set Intel CPU turbo to: {}", enabled);
+        log::info!(target: "hw.cpu", "set_intel_turbo enabled={}", enabled);
         return Ok(());
     }
     
@@ -91,7 +91,7 @@ pub fn set_cpu_boost(enabled: bool) -> Result<()> {
     let amd_pstate_boost = "/sys/devices/system/cpu/amd_pstate/cpb_boost";
     if Path::new(amd_pstate_boost).exists() {
         fs::write(amd_pstate_boost, if enabled { "1" } else { "0" })?;
-        log::info!("Set AMD P-State boost to: {}", enabled);
+        log::info!(target: "hw.cpu", "set_amd_pstate_boost enabled={}", enabled);
         return Ok(());
     }
     
@@ -105,7 +105,7 @@ pub fn set_smt(enabled: bool) -> Result<()> {
     }
     
     fs::write(path, if enabled { "on" } else { "off" })?;
-    log::info!("Set SMT to: {}", if enabled { "on" } else { "off" });
+    log::info!(target: "hw.cpu", "set_smt enabled={}", enabled);
     Ok(())
 }
 
@@ -120,7 +120,7 @@ pub fn set_amd_pstate_status(status: &str) -> Result<()> {
     }
     
     fs::write(path, status)?;
-    log::info!("Set AMD pstate status to: {}", status);
+    log::info!(target: "hw.cpu", "set_amd_pstate_status status=\"{}\"", status);
     Ok(())
 }
 
@@ -135,12 +135,12 @@ pub fn set_intel_pstate_status(status: &str) -> Result<()> {
     }
 
     fs::write(path, status)?;
-    log::info!("Set Intel pstate status to: {}", status);
+    log::info!(target: "hw.cpu", "set_intel_pstate_status status=\"{}\"", status);
     Ok(())
 }
 
 pub fn apply_profile(profile: &Profile) -> Result<()> {
-    log::info!("Applying profile: {}", profile.name);
+    log::info!(target: "hw.detect", "Applying profile: {}", profile.name);
     
     // Apply CPU settings
     if let Some(ref governor) = profile.cpu_settings.governor {
@@ -212,13 +212,13 @@ pub fn apply_profile(profile: &Profile) -> Result<()> {
         }
     }
     
-    log::info!("Profile '{}' applied successfully", profile.name);
+    log::info!(target: "hw.detect", "Profile '{}' applied successfully", profile.name);
     Ok(())
 }
 
 pub fn apply_battery_settings(settings: &BatterySettings) -> Result<()> {
     if !crate::battery_control::BatteryControl::is_available() {
-        log::info!("Battery control not available, skipping");
+        log::debug!(target: "hw.battery", "Battery control not available, skipping");
         return Ok(());
     }
 
@@ -228,14 +228,14 @@ pub fn apply_battery_settings(settings: &BatterySettings) -> Result<()> {
         battery.set_charge_type("Custom")?;
         battery.set_charge_control_start_threshold(settings.charge_start_threshold)?;
         battery.set_charge_control_end_threshold(settings.charge_end_threshold)?;
-        log::info!(
-            "Set battery thresholds: start={}, end={}",
+        log::info!(target: "hw.battery",
+            "set_thresholds enabled=true start={} end={}",
             settings.charge_start_threshold,
             settings.charge_end_threshold
         );
     } else {
         battery.set_charge_type("Standard")?;
-        log::info!("Set battery charge type to Standard");
+        log::info!(target: "hw.battery", "set_thresholds enabled=false mode=\"Standard\"");
     }
 
     Ok(())
@@ -243,7 +243,7 @@ pub fn apply_battery_settings(settings: &BatterySettings) -> Result<()> {
 
 fn apply_keyboard_settings(settings: &KeyboardSettings) -> Result<()> {
     if !settings.control_enabled {
-        log::info!("Keyboard control disabled, setting to default white");
+        log::info!(target: "hw.kbd", "keyboard_control enabled=false");
         if let Ok(kbd) = RgbKeyboardControl::new() {
             let white_mode = KeyboardMode::SingleColor {
                 r: 255,
@@ -258,10 +258,10 @@ fn apply_keyboard_settings(settings: &KeyboardSettings) -> Result<()> {
     
     if let Ok(kbd) = RgbKeyboardControl::new() {
         kbd.set_mode(&settings.mode)?;
-        log::info!("✅ Keyboard settings applied successfully");
+        log::info!(target: "hw.kbd", "keyboard_settings applied=true");
         Ok(())
     } else {
-        log::warn!("Keyboard control not available");
+        log::warn!(target: "hw.kbd", "Keyboard control not available");
         Err(anyhow!("Keyboard control not available"))
     }
 }
@@ -277,7 +277,7 @@ pub fn preview_keyboard_settings(settings: &KeyboardSettings) -> Result<()> {
 
 fn apply_screen_settings(settings: &ScreenSettings) -> Result<()> {
     if settings.system_control {
-        log::info!("Using system screen brightness control");
+        log::debug!(target: "hw.screen", "Using system screen brightness control");
         return Ok(());
     }
     
@@ -304,18 +304,18 @@ fn apply_screen_settings(settings: &ScreenSettings) -> Result<()> {
             let actual_path = format!("{}/actual_brightness", base_path);
             if Path::new(&actual_path).exists() {
                 if let Err(e) = fs::write(&actual_path, actual_brightness.to_string()) {
-                    log::warn!("Could not write to actual_brightness: {}", e);
+                    log::warn!(target: "hw.screen", "Could not write to actual_brightness: {}", e);
                 }
             }
             
             // Then write to brightness
             match fs::write(&brightness_path, actual_brightness.to_string()) {
                 Ok(_) => {
-                    log::info!("Set screen brightness to {}% at {}", settings.brightness, base_path);
+                    log::info!(target: "hw.screen", "set_brightness level={}% path=\"{}\"", settings.brightness, base_path);
                     return Ok(());
                 }
                 Err(e) => {
-                    log::warn!("Failed to set brightness at {}: {}", base_path, e);
+                    log::warn!(target: "hw.screen", "Failed to set brightness at {}: {}", base_path, e);
                     continue;
                 }
             }
@@ -335,7 +335,7 @@ pub fn set_tdp_profile(profile_name: &str) -> Result<()> {
     
     if let Some(profile_id) = profiles.iter().position(|p| p == profile_name) {
         io.set_performance_profile(profile_id as u32)?;
-        log::info!("Set TDP profile to: {} (id: {})", profile_name, profile_id);
+        log::info!(target: "hw.cpu", "set_tdp_profile name=\"{}\" id={}", profile_name, profile_id);
         Ok(())
     } else {
         Err(anyhow!("Profile '{}' not found. Available: {:?}", profile_name, profiles))
@@ -348,11 +348,11 @@ pub fn set_fan_speed(fan_id: u32, speed_percent: u32) -> Result<()> {
     }
     
     let speed = speed_percent.min(100);
-    log::info!("DBus request: set fan {} to {}%", fan_id, speed);
+    log::debug!(target: "hw.fan", "DBus request: set fan {} to {}%", fan_id, speed);
     let io = TuxedoIo::new()?;
     io.set_fan_speed(fan_id, speed)?;
     
-    log::info!("Set fan {} to {}%", fan_id, speed);
+    log::info!(target: "hw.fan", "set_fan id={} speed={}%", fan_id, speed);
     Ok(())
 }
 
@@ -364,33 +364,32 @@ pub fn set_fan_auto(_fan_id: u32) -> Result<()> {
     let io = TuxedoIo::new()?;
     io.set_fan_auto()?;
     
-    log::info!("Set all fans to auto mode");
+    log::info!(target: "hw.fan", "set_fans_auto");
     Ok(())
 }
 
 fn apply_fan_settings(settings: &FanSettings) -> Result<()> {
     if !TuxedoIo::is_available() {
-        log::info!("Fan control not available (/dev/tuxedo_io not present)");
+        log::debug!(target: "hw.fan", "Fan control not available (/dev/tuxedo_io not present)");
         return Ok(());
     }
     
-    log::info!("Applying fan settings: enabled={}", settings.control_enabled);
+    log::debug!(target: "hw.fan", "Applying fan settings: enabled={}", settings.control_enabled);
     
     // Update the global fan daemon state
     {
         let mut state = crate::FAN_DAEMON_STATE.lock().unwrap();
         if settings.control_enabled {
             *state = Some(settings.clone());
-            log::info!("Fan daemon: enabled with {} curves", settings.curves.len());
+            log::info!(target: "hw.fan", "fan_daemon enabled=true curves={}", settings.curves.len());
         } else {
             *state = None;
-            log::info!("Fan daemon: disabled");
+            log::info!(target: "hw.fan", "fan_daemon enabled=false");
         }
     }
     
     if !settings.control_enabled {
         set_fan_auto(0)?;
-        log::info!("Set all fans to auto mode");
     }
     
     Ok(())
@@ -404,7 +403,7 @@ pub fn set_webcam_state(enabled: bool) -> Result<()> {
     let io = TuxedoIo::new()?;
     io.set_webcam_state(enabled)?;
     
-    log::info!("Set webcam to: {}", if enabled { "enabled" } else { "disabled" });
+    log::info!(target: "hw.detect", "set_webcam enabled={}", enabled);
     Ok(())
 }
 
@@ -479,7 +478,7 @@ pub fn set_gpu_core_offset(device_index: u32, offset: f32) -> Result<()> {
         let entry = map.entry(device_index).or_insert((0.0, 0.0));
         entry.0 = offset;
     }
-    log::info!("Set GPU core offset to {} MHz (rounded to {}) for device {}", offset, offset.round(), device_index);
+    log::info!(target: "hw.gpu", "set_core_offset gpu={} offset={} offset_rounded={}", device_index, offset, offset.round());
     Ok(())
 }
 
@@ -492,7 +491,7 @@ pub fn set_gpu_memory_offset(device_index: u32, offset: f32) -> Result<()> {
         let entry = map.entry(device_index).or_insert((0.0, 0.0));
         entry.1 = offset;
     }
-    log::info!("Set GPU memory offset to {} MHz (rounded to {}) for device {}", offset, offset.round(), device_index);
+    log::info!(target: "hw.gpu", "set_mem_offset gpu={} offset={} offset_rounded={}", device_index, offset, offset.round());
     Ok(())
 }
 
@@ -500,7 +499,7 @@ pub fn set_gpu_power_limit(device_index: u32, limit_watts: u32) -> Result<()> {
     let nvml = get_nvml()?;
     let mut device = nvml.device_by_index(device_index)?;
     device.set_power_management_limit(limit_watts * 1000)?; // Watts to mW
-    log::info!("Set NVIDIA GPU {} power limit to {} W", device_index, limit_watts);
+    log::info!(target: "hw.gpu", "set_power_limit gpu={} limit={}W", device_index, limit_watts);
     Ok(())
 }
 
@@ -508,7 +507,7 @@ pub fn set_gpu_fan_speed(device_index: u32, fan_index: u32, speed_percent: u32) 
     let nvml = get_nvml()?;
     let mut device = nvml.device_by_index(device_index)?;
     device.set_fan_speed(fan_index, speed_percent)?;
-    log::info!("Set NVIDIA GPU {} fan {} to {}%", device_index, fan_index, speed_percent);
+    log::info!(target: "hw.gpu", "set_fan_speed gpu={} fan={} speed={}%", device_index, fan_index, speed_percent);
     Ok(())
 }
 
@@ -516,7 +515,7 @@ pub fn set_gpu_fan_auto(device_index: u32, fan_index: u32) -> Result<()> {
     let nvml = get_nvml()?;
     let mut device = nvml.device_by_index(device_index)?;
     device.set_default_fan_speed(fan_index)?;
-    log::info!("Set NVIDIA GPU {} fan {} to auto mode", device_index, fan_index);
+    log::info!(target: "hw.gpu", "set_fan_auto gpu={} fan={}", device_index, fan_index);
     Ok(())
 }
 
@@ -546,7 +545,7 @@ pub fn set_prime_profile(profile: &str) -> Result<()> {
             _ => profile,
         };
 
-        log::info!("Using optimus-manager to switch to {} mode", opt_mode);
+        log::info!(target: "hw.gpu", "set_prime_profile mode=\"{}\" tool=\"optimus-manager\"", opt_mode);
         let output = std::process::Command::new(path)
             .arg("--switch")
             .arg(opt_mode)
@@ -566,7 +565,7 @@ pub fn set_prime_profile(profile: &str) -> Result<()> {
     if !output.status.success() {
         return Err(anyhow!("prime-select command failed: {}", String::from_utf8_lossy(&output.stderr)));
     }
-    log::info!("Set prime profile to: {}", profile);
+    log::info!(target: "hw.gpu", "set_prime_profile mode=\"{}\" tool=\"prime-select\"", profile);
     Ok(())
 }
 
@@ -587,7 +586,7 @@ pub fn set_energy_performance_preference(epp: &str) -> Result<()> {
         }
     }
     
-    log::info!("Set energy performance preference to: {}", epp);
+    log::info!(target: "hw.cpu", "set_epp preference=\"{}\"", epp);
     Ok(())
 }
 
@@ -677,7 +676,7 @@ impl RgbKeyboardControl {
         let color_str = format!("{} {} {}", red, green, blue);
         fs::write(&color_path, color_str)?;
         
-        log::info!("Set keyboard zone {} RGB color: ({}, {}, {})", zone_idx, red, green, blue);
+        log::info!(target: "hw.kbd", "set_zone_color zone={} r={} g={} b={}", zone_idx, red, green, blue);
         Ok(())
     }
     
@@ -702,7 +701,7 @@ impl RgbKeyboardControl {
             let _ = fs::write(&brightness_path, actual_brightness.to_string());
         }
         
-        log::info!("Set keyboard brightness to {}% for all zones", brightness);
+        log::info!(target: "hw.kbd", "set_brightness level={}%", brightness);
         Ok(())
     }
     
@@ -759,7 +758,7 @@ impl RgbKeyboardControl {
                     let _ = self.set_zone_color(i, *r, *g, *b);
                 }
                 self.set_brightness(*brightness)?;
-                log::info!("Set breathing mode with speed {}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"breathing\" speed={}", speed);
             }
             KeyboardMode::Wave { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -770,7 +769,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(7, "wave")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::info!("Set wave mode with speed {}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"wave\" speed={}", speed);
             }
             KeyboardMode::Cycle { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -781,7 +780,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(2, "cycle")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::info!("Set cycle mode with speed {}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"cycle\" speed={}", speed);
             }
             KeyboardMode::Dance { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -792,7 +791,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(3, "dance")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::info!("Set dance mode with speed {}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"dance\" speed={}", speed);
             }
             KeyboardMode::Flash { r, g, b, brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -806,7 +805,7 @@ impl RgbKeyboardControl {
                     let _ = self.set_zone_color(i, *r, *g, *b);
                 }
                 self.set_brightness(*brightness)?;
-                log::info!("Set flash mode with speed {}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"flash\" speed={}", speed);
             }
             KeyboardMode::RandomColor { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -817,7 +816,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(5, "random")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::info!("Set random color mode with speed {}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"random\" speed={}", speed);
             }
             KeyboardMode::Tempo { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -828,7 +827,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(6, "tempo")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::info!("Set tempo mode with speed {}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"tempo\" speed={}", speed);
             }
         }
         Ok(())

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -641,7 +641,7 @@ fn read_available_epp_options() -> Vec<String> {
 
 pub fn get_tdp_profiles() -> Result<Vec<String>> {
     if !TuxedoIo::is_available() {
-        log::info!("TDP profiles not available (/dev/tuxedo_io not present)");
+        log::debug!(target: "hw.detect", "TDP profiles not available (/dev/tuxedo_io not present)");
         return Ok(vec![]);
     }
     
@@ -649,17 +649,22 @@ pub fn get_tdp_profiles() -> Result<Vec<String>> {
         Ok(io) => {
             match io.get_available_profiles() {
                 Ok(profiles) => {
-                    log::info!("Available TDP profiles: {:?}", profiles);
+                    static LOGGED_ONCE: Mutex<bool> = Mutex::new(false);
+                    let mut logged = LOGGED_ONCE.lock().unwrap();
+                    if !*logged {
+                        log::info!(target: "hw.detect", "Available TDP profiles: {:?}", profiles);
+                        *logged = true;
+                    }
                     Ok(profiles)
                 }
                 Err(e) => {
-                    log::warn!("Failed to get TDP profiles: {}", e);
+                    log::warn!(target: "hw.detect", "Failed to get TDP profiles: {}", e);
                     Ok(vec![])
                 }
             }
         }
         Err(e) => {
-            log::warn!("Failed to open /dev/tuxedo_io: {}", e);
+            log::warn!(target: "hw.detect", "Failed to open /dev/tuxedo_io: {}", e);
             Ok(vec![])
         }
     }
@@ -1676,14 +1681,14 @@ struct NvApiVoltage {
 // Function to get NVIDIA extended stats (hotspot, memory temp, voltage)
 fn get_vram_info(minor_number: u32) -> (Option<String>, Option<String>, Option<u32>, Option<f32>) {
     // Returns (type, vendor, bus_width, bandwidth)
-    log::info!("Attempting to get VRAM info for NVIDIA device minor {}", minor_number);
+    log::debug!(target: "hw.detect", "Attempting to get VRAM info for NVIDIA device minor {}", minor_number);
     match NvidiaDriverHandle::open(minor_number) {
         Ok(handle) => {
             let ram_type_val = handle.get_fb_info(NV2080_CTRL_FB_INFO_INDEX_RAM_TYPE).ok();
             let bus_width = handle.get_fb_info(NV2080_CTRL_FB_INFO_INDEX_BUS_WIDTH).ok();
             let vendor_id = handle.get_fb_info(NV2080_CTRL_FB_INFO_INDEX_MEMORYINFO_VENDOR_ID).ok();
 
-            log::info!("VRAM raw info for minor {}: type={:?}, bus={:?}, vendor={:?}",
+            log::debug!(target: "hw.detect", "VRAM raw info for minor {}: type={:?}, bus={:?}, vendor={:?}",
                 minor_number, ram_type_val, bus_width, vendor_id);
 
             let ram_type = ram_type_val.map(|v| match v {
@@ -1730,7 +1735,7 @@ fn get_vram_info(minor_number: u32) -> (Option<String>, Option<String>, Option<u
             (ram_type, vendor, bus_width, None)
         }
         Err(e) => {
-            log::warn!("Failed to open NvidiaDriverHandle for minor {}: {}", minor_number, e);
+            log::warn!(target: "hw.detect", "Failed to open NvidiaDriverHandle for minor {}: {}", minor_number, e);
             (None, None, None, None)
         }
     }
@@ -2494,7 +2499,7 @@ pub fn get_wifi_info() -> Result<Vec<WiFiInfo>> {
         // Calculate actual throughput
         let (tx_rate, rx_rate) = read_wifi_rates(&interface, final_tx_bytes, final_rx_bytes);
         
-        log::info!("WiFi {} details: SSID={:?}, Signal={:?}, Channel={:?}, Rates={:?}/{:?}",
+        log::debug!(target: "hw.detect", "WiFi {} details: SSID={:?}, Signal={:?}, Channel={:?}, Rates={:?}/{:?}",
                    interface, ssid, signal_level, channel, tx_rate, rx_rate);
 
         wifi_devices.push(WiFiInfo {

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -649,7 +649,7 @@ pub fn get_tdp_profiles() -> Result<Vec<String>> {
         Ok(io) => {
             match io.get_available_profiles() {
                 Ok(profiles) => {
-                    log::info!("Available TDP profiles: {:?}", profiles);
+                    log::debug!("Available TDP profiles: {:?}", profiles);
                     Ok(profiles)
                 }
                 Err(e) => {
@@ -2494,7 +2494,7 @@ pub fn get_wifi_info() -> Result<Vec<WiFiInfo>> {
         // Calculate actual throughput
         let (tx_rate, rx_rate) = read_wifi_rates(&interface, final_tx_bytes, final_rx_bytes);
         
-        log::info!("WiFi {} details: SSID={:?}, Signal={:?}, Channel={:?}, Rates={:?}/{:?}",
+        log::debug!("WiFi {} details: SSID={:?}, Signal={:?}, Channel={:?}, Rates={:?}/{:?}",
                    interface, ssid, signal_level, channel, tx_rate, rx_rate);
 
         wifi_devices.push(WiFiInfo {

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -1676,11 +1676,15 @@ struct NvApiVoltage {
 // Function to get NVIDIA extended stats (hotspot, memory temp, voltage)
 fn get_vram_info(minor_number: u32) -> (Option<String>, Option<String>, Option<u32>, Option<f32>) {
     // Returns (type, vendor, bus_width, bandwidth)
+    log::debug!("Attempting to get VRAM info for NVIDIA device minor {}", minor_number);
     match NvidiaDriverHandle::open(minor_number) {
         Ok(handle) => {
             let ram_type_val = handle.get_fb_info(NV2080_CTRL_FB_INFO_INDEX_RAM_TYPE).ok();
             let bus_width = handle.get_fb_info(NV2080_CTRL_FB_INFO_INDEX_BUS_WIDTH).ok();
             let vendor_id = handle.get_fb_info(NV2080_CTRL_FB_INFO_INDEX_MEMORYINFO_VENDOR_ID).ok();
+
+            log::debug!("VRAM raw info for minor {}: type={:?}, bus={:?}, vendor={:?}",
+                minor_number, ram_type_val, bus_width, vendor_id);
 
             let ram_type = ram_type_val.map(|v| match v {
                 0x00000001 => "SDRAM",
@@ -1725,7 +1729,10 @@ fn get_vram_info(minor_number: u32) -> (Option<String>, Option<String>, Option<u
 
             (ram_type, vendor, bus_width, None)
         }
-        Err(_) => (None, None, None, None),
+        Err(e) => {
+            log::warn!("Failed to open NvidiaDriverHandle for minor {}: {}", minor_number, e);
+            (None, None, None, None)
+        }
     }
 }
 
@@ -2148,6 +2155,15 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                     }
                 }
 
+                // Fallback for memory clock range
+                if mem_range.is_none() {
+                    if let Ok(clocks) = device.supported_memory_clocks() {
+                        if let (Some(&c_min), Some(&c_max)) = (clocks.iter().min(), clocks.iter().max()) {
+                            mem_range = Some((c_min, c_max));
+                        }
+                    }
+                }
+
                 let meta = NvidiaMetadata {
                     architecture: arch,
                     supported_p_states: p_states,
@@ -2179,8 +2195,18 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         let mut v_bw = None;
 
         if let (Some(bus), Some((_, max_mem))) = (v_bus, memory_clock_range) {
-            // Approximate max bandwidth: (Max Clock * 2 (DDR) * Bus Width) / 8 / 1000
-            v_bw = Some((max_mem as f32 * 2.0 * bus as f32) / 8000.0);
+            let mut multiplier = 2.0; // Default for DDR
+            if let Some(ref t) = v_type {
+                if t.contains("GDDR6X") {
+                    multiplier = 16.0;
+                } else if t.contains("GDDR6") {
+                    multiplier = 8.0;
+                } else if t.contains("GDDR5") {
+                    multiplier = 4.0;
+                }
+            }
+            // Bandwidth (GB/s) = (Clock * Multiplier * Bus Width) / 8 bits / 1000 MHz
+            v_bw = Some((max_mem as f32 * multiplier * bus as f32) / 8000.0);
         }
 
         let mut gpu_info = GpuInfo {

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -649,7 +649,7 @@ pub fn get_tdp_profiles() -> Result<Vec<String>> {
         Ok(io) => {
             match io.get_available_profiles() {
                 Ok(profiles) => {
-                    log::debug!("Available TDP profiles: {:?}", profiles);
+                    log::info!("Available TDP profiles: {:?}", profiles);
                     Ok(profiles)
                 }
                 Err(e) => {
@@ -1676,14 +1676,14 @@ struct NvApiVoltage {
 // Function to get NVIDIA extended stats (hotspot, memory temp, voltage)
 fn get_vram_info(minor_number: u32) -> (Option<String>, Option<String>, Option<u32>, Option<f32>) {
     // Returns (type, vendor, bus_width, bandwidth)
-    log::debug!("Attempting to get VRAM info for NVIDIA device minor {}", minor_number);
+    log::info!("Attempting to get VRAM info for NVIDIA device minor {}", minor_number);
     match NvidiaDriverHandle::open(minor_number) {
         Ok(handle) => {
             let ram_type_val = handle.get_fb_info(NV2080_CTRL_FB_INFO_INDEX_RAM_TYPE).ok();
             let bus_width = handle.get_fb_info(NV2080_CTRL_FB_INFO_INDEX_BUS_WIDTH).ok();
             let vendor_id = handle.get_fb_info(NV2080_CTRL_FB_INFO_INDEX_MEMORYINFO_VENDOR_ID).ok();
 
-            log::debug!("VRAM raw info for minor {}: type={:?}, bus={:?}, vendor={:?}",
+            log::info!("VRAM raw info for minor {}: type={:?}, bus={:?}, vendor={:?}",
                 minor_number, ram_type_val, bus_width, vendor_id);
 
             let ram_type = ram_type_val.map(|v| match v {
@@ -2494,7 +2494,7 @@ pub fn get_wifi_info() -> Result<Vec<WiFiInfo>> {
         // Calculate actual throughput
         let (tx_rate, rx_rate) = read_wifi_rates(&interface, final_tx_bytes, final_rx_bytes);
         
-        log::debug!("WiFi {} details: SSID={:?}, Signal={:?}, Channel={:?}, Rates={:?}/{:?}",
+        log::info!("WiFi {} details: SSID={:?}, Signal={:?}, Channel={:?}, Rates={:?}/{:?}",
                    interface, ssid, signal_level, channel, tx_rate, rx_rate);
 
         wifi_devices.push(WiFiInfo {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -81,6 +81,9 @@ impl log::Log for DaemonLogger {
 #[tokio::main]
 async fn main() -> Result<()> {
     let mut builder = env_logger::Builder::from_default_env();
+    if std::env::var("RUST_LOG").is_err() {
+        builder.filter_level(log::LevelFilter::Info);
+    }
     let inner = builder.build();
     let max_level = inner.filter();
     let logger = DaemonLogger { inner };

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -59,6 +59,7 @@ impl log::Log for DaemonLogger {
         if record.level() <= log::Level::Info || self.inner.enabled(record.metadata()) {
             let entry = LogEntry {
                 level: record.level().to_string(),
+                target: record.target().to_string(),
                 message: record.args().to_string(),
                 timestamp: chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
             };
@@ -88,6 +89,7 @@ async fn main() -> Result<()> {
     let mut builder = env_logger::Builder::from_default_env();
     if std::env::var("RUST_LOG").is_err() {
         builder.filter_level(log::LevelFilter::Info);
+        builder.filter(Some("zbus"), log::LevelFilter::Warn);
     }
     let inner = builder.build();
     let _max_level = inner.filter();
@@ -97,8 +99,6 @@ async fn main() -> Result<()> {
     log::set_max_level(log::LevelFilter::Debug); // Allow up to Debug to reach our logger for buffer
 
     log::info!("Starting LapSphere Daemon");
-    log::warn!("Test Warning Log: Log system initialized");
-    log::error!("Test Error Log: System ready");
 
     let args: Vec<String> = std::env::args().collect();
 
@@ -296,7 +296,7 @@ async fn main() -> Result<()> {
         move || {
             let tick = log_tick.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
             if tick % 60 == 0 {
-                log::warn!("Daemon heartbeat. Uptime tick: {}", tick);
+                log::warn!(target: "daemon", "heartbeat uptime_tick={}", tick);
             }
             gpu_poll_fn()
         }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -50,11 +50,13 @@ struct DaemonLogger {
 
 impl log::Log for DaemonLogger {
     fn enabled(&self, metadata: &log::Metadata) -> bool {
-        self.inner.enabled(metadata)
+        // Operational levels are always enabled for internal buffer
+        metadata.level() <= log::Level::Info || self.inner.enabled(metadata)
     }
 
     fn log(&self, record: &log::Record) {
-        if self.enabled(record.metadata()) {
+        // Always capture operational logs into the buffer
+        if record.level() <= log::Level::Info || self.inner.enabled(record.metadata()) {
             let entry = LogEntry {
                 level: record.level().to_string(),
                 message: record.args().to_string(),
@@ -63,12 +65,15 @@ impl log::Log for DaemonLogger {
 
             {
                 let mut logs = DAEMON_LOGS.lock().unwrap();
-                if logs.len() >= 500 {
+                if logs.len() >= 1000 {
                     logs.pop_front();
                 }
                 logs.push_back(entry);
             }
+        }
 
+        // Only log to console if env_logger allows it
+        if self.inner.enabled(record.metadata()) {
             self.inner.log(record);
         }
     }
@@ -85,11 +90,11 @@ async fn main() -> Result<()> {
         builder.filter_level(log::LevelFilter::Info);
     }
     let inner = builder.build();
-    let max_level = inner.filter();
+    let _max_level = inner.filter();
     let logger = DaemonLogger { inner };
 
     log::set_boxed_logger(Box::new(logger)).unwrap();
-    log::set_max_level(max_level);
+    log::set_max_level(log::LevelFilter::Debug); // Allow up to Debug to reach our logger for buffer
 
     log::info!("Starting LapSphere Daemon");
     log::warn!("Test Warning Log: Log system initialized");
@@ -285,10 +290,22 @@ async fn main() -> Result<()> {
         Ok(())
     };
 
+    let log_tick = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let gpu_job_poll = {
+        let log_tick = log_tick.clone();
+        move || {
+            let tick = log_tick.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            if tick % 60 == 0 {
+                log::warn!("Daemon heartbeat. Uptime tick: {}", tick);
+            }
+            gpu_poll_fn()
+        }
+    };
+
     let gpu_job = PollJob::new(
         "gpu_overclock".to_string(),
         Duration::from_millis(1000), // Default 1s
-        gpu_poll_fn,
+        gpu_job_poll,
     );
 
     if let Err(e) = scheduler_handle.add_job(gpu_job) {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -42,7 +42,7 @@ pub static MANUAL_GPU_OFFSETS: once_cell::sync::Lazy<Arc<Mutex<HashMap<u32, (f32
     once_cell::sync::Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
 
 pub static DAEMON_LOGS: once_cell::sync::Lazy<Arc<Mutex<VecDeque<LogEntry>>>> =
-    once_cell::sync::Lazy::new(|| Arc::new(Mutex::new(VecDeque::with_capacity(100))));
+    once_cell::sync::Lazy::new(|| Arc::new(Mutex::new(VecDeque::with_capacity(500))));
 
 struct DaemonLogger {
     inner: env_logger::Logger,
@@ -63,7 +63,7 @@ impl log::Log for DaemonLogger {
 
             {
                 let mut logs = DAEMON_LOGS.lock().unwrap();
-                if logs.len() >= 100 {
+                if logs.len() >= 500 {
                     logs.pop_front();
                 }
                 logs.push_back(entry);
@@ -92,6 +92,8 @@ async fn main() -> Result<()> {
     log::set_max_level(max_level);
 
     log::info!("Starting LapSphere Daemon");
+    log::warn!("Test Warning Log: Log system initialized");
+    log::error!("Test Error Log: System ready");
 
     let args: Vec<String> = std::env::args().collect();
 

--- a/daemon/src/tuxedo_io.rs
+++ b/daemon/src/tuxedo_io.rs
@@ -132,7 +132,10 @@ impl TuxedoIo {
         let interface = Self::detect_interface(&device)?;
         let fan_count = Self::detect_fan_count(&device, interface)?;
 
-        log::info!("Detected interface: {:?}, fan count: {}", interface, fan_count);
+        static LOGGED_ONCE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+        if !LOGGED_ONCE.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            log::info!(target: "hw.detect", "platform={:?} fan_count={}", interface, fan_count);
+        }
 
         Ok(TuxedoIo {
             device,
@@ -174,28 +177,28 @@ impl TuxedoIo {
         let uw_res = Self::ioctl_read_i32(fd, uw_check);
 
         if matches!(cl_res, Ok(1)) {
-            log::debug!("Detected Clevo interface via hardware check");
+            log::debug!(target: "hw.detect", "Detected Clevo interface via hardware check");
             return Ok(HardwareInterface::Clevo);
         }
         if matches!(uw_res, Ok(1)) {
-            log::debug!("Detected Uniwill interface via hardware check");
+            log::debug!(target: "hw.detect", "Detected Uniwill interface via hardware check");
             return Ok(HardwareInterface::Uniwill);
         }
 
         // Fallback: try to read faninfo to detect interface
         let probe_cl = Self::ioctl_read_i32(fd, Self::ior(MAGIC_READ_CL, 0x10, Self::PTR_SIZE));
         if probe_cl.is_ok() {
-            log::debug!("Detected Clevo interface via faninfo probe");
+            log::debug!(target: "hw.detect", "Detected Clevo interface via faninfo probe");
             return Ok(HardwareInterface::Clevo);
         }
 
         let probe_uw = Self::ioctl_read_i32(fd, Self::ior(MAGIC_READ_UW, 0x10, Self::PTR_SIZE));
         if probe_uw.is_ok() {
-            log::debug!("Detected Uniwill interface via fanspeed probe");
+            log::debug!(target: "hw.detect", "Detected Uniwill interface via fanspeed probe");
             return Ok(HardwareInterface::Uniwill);
         }
 
-        log::warn!("No hardware interface detected");
+        log::warn!(target: "hw.detect", "No hardware interface detected");
         Ok(HardwareInterface::None)
     }
 
@@ -279,7 +282,7 @@ impl TuxedoIo {
                 let speed_percent = speed_percent.min(100);
                 
                 // Step 1: Disable auto mode (critical for Clevo!)
-                log::debug!("Disabling Clevo auto mode for manual fan control");
+                log::debug!(target: "hw.fan", "Disabling Clevo auto mode for manual fan control");
                 let manual_val: i32 = 0;
                 let auto_request = Self::iow(MAGIC_WRITE_CL, 0x11, Self::PTR_SIZE);
                 Self::ioctl_write_i32(fd, auto_request, manual_val)?;
@@ -306,7 +309,7 @@ impl TuxedoIo {
                     | ((current_raw[1] as i32) << 8)
                     | ((current_raw[2] as i32) << 16);
 
-                log::debug!(
+                log::debug!(target: "hw.fan",
                     "Setting Clevo fan {} to {}% (raw: {:#04x}), packed: {:#08x}",
                     fan_id, speed_percent, current_raw[fan_id as usize], packed
                 );
@@ -315,7 +318,7 @@ impl TuxedoIo {
                 let speed_request = Self::iow(MAGIC_WRITE_CL, 0x10, Self::PTR_SIZE);
                 Self::ioctl_write_i32(fd, speed_request, packed)?;
 
-                log::info!("Successfully set Clevo fan {} to {}%", fan_id, speed_percent);
+                log::info!(target: "hw.fan", "set_clevo_fan id={} speed={}%", fan_id, speed_percent);
                 Ok(())
             }
 
@@ -327,12 +330,12 @@ impl TuxedoIo {
                     _ => return Err(anyhow!("Invalid Uniwill fan ID: {}", fan_id)),
                 };
 
-                log::debug!("Setting Uniwill fan {} to {}%", fan_id, speed_percent);
+                log::debug!(target: "hw.fan", "Setting Uniwill fan {} to {}%", fan_id, speed_percent);
 
                 let request = Self::iow(MAGIC_WRITE_UW, seq, Self::PTR_SIZE);
                 Self::ioctl_write_i32(fd, request, val)?;
 
-                log::info!("Successfully set Uniwill fan {} to {}%", fan_id, speed_percent);
+                log::info!(target: "hw.fan", "set_uniwill_fan id={} speed={}%", fan_id, speed_percent);
                 Ok(())
             }
 
@@ -346,23 +349,23 @@ impl TuxedoIo {
         match self.interface {
             HardwareInterface::Clevo => {
                 let auto_val: i32 = 0xF;
-                log::debug!("Setting Clevo fans to auto mode");
+                log::debug!(target: "hw.fan", "Setting Clevo fans to auto mode");
                 
                 let request = Self::iow(MAGIC_WRITE_CL, 0x11, Self::PTR_SIZE);
                 Self::ioctl_write_i32(fd, request, auto_val)?;
                 
-                log::info!("Successfully set Clevo fans to auto mode");
+                log::info!(target: "hw.fan", "set_clevo_fans_auto");
                 Ok(())
             }
 
             HardwareInterface::Uniwill => {
-                log::debug!("Setting Uniwill fans to auto mode");
+                log::debug!(target: "hw.fan", "Setting Uniwill fans to auto mode");
                 
                 // Uniwill uses _IO (no data argument)
                 let request = Self::io(MAGIC_WRITE_UW, 0x14);
                 Self::ioctl_write_only(fd, request, 1)?;
                 
-                log::info!("Successfully set Uniwill fans to auto mode");
+                log::info!(target: "hw.fan", "set_uniwill_fans_auto");
                 Ok(())
             }
 
@@ -521,12 +524,12 @@ impl TuxedoIo {
                     return Err(anyhow!("Invalid Clevo profile ID: {}", profile_id));
                 }
                 
-                log::debug!("Setting Clevo performance profile to {}", profile_id);
+                log::debug!(target: "hw.detect", "Setting Clevo performance profile to {}", profile_id);
                 
                 let request = Self::iow(MAGIC_WRITE_CL, 0x15, Self::PTR_SIZE);
                 Self::ioctl_write_i32(fd, request, profile_id as i32)?;
                 
-                log::info!("Successfully set Clevo performance profile to {}", profile_id);
+                log::info!(target: "hw.detect", "set_clevo_perf_profile id={}", profile_id);
                 Ok(())
             }
             HardwareInterface::Uniwill => {
@@ -534,12 +537,12 @@ impl TuxedoIo {
                     return Err(anyhow!("Invalid Uniwill profile ID: {}", profile_id));
                 }
                 
-                log::debug!("Setting Uniwill performance profile to {}", profile_id);
+                log::debug!(target: "hw.detect", "Setting Uniwill performance profile to {}", profile_id);
                 
                 let request = Self::iow(MAGIC_WRITE_UW, 0x18, Self::PTR_SIZE);
                 Self::ioctl_write_i32(fd, request, profile_id as i32)?;
                 
-                log::info!("Successfully set Uniwill performance profile to {}", profile_id);
+                log::info!(target: "hw.detect", "set_uniwill_perf_profile id={}", profile_id);
                 Ok(())
             }
             HardwareInterface::None => Err(anyhow!("No hardware interface available")),

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -62,6 +62,7 @@ pub struct AppState {
     pub log_filter_info: bool,
     pub log_filter_warn: bool,
     pub log_filter_error: bool,
+    pub log_paused: bool,
     
     // UI state
     pub current_page: Page,
@@ -119,6 +120,7 @@ impl AppState {
             log_filter_info: true,
             log_filter_warn: true,
             log_filter_error: true,
+            log_paused: false,
             keyboard_capabilities: None,
             current_page: Page::Statistics,
             settings_tab: SettingsTab::Main,
@@ -500,7 +502,9 @@ impl LapSphereApp {
                     self.state.webcam_enabled = Some(state);
                 }
                 HardwareUpdate::DaemonLogs(logs) => {
-                    self.state.daemon_logs = logs;
+                    if !self.state.log_paused {
+                        self.state.daemon_logs = logs;
+                    }
                 }
                 HardwareUpdate::UpdateInfo(version, changelog) => {
                     self.state.new_version_available = Some(version);

--- a/gui/src/pages/settings.rs
+++ b/gui/src/pages/settings.rs
@@ -39,7 +39,16 @@ pub fn draw(ui: &mut Ui, state: &mut AppState, theme: &mut LapSphereTheme, ctx: 
 }
 
 fn draw_logs_view(ui: &mut Ui, state: &mut AppState, ctx: &Context) {
-    ui.label(RichText::new("Daemon Logs (last 100 lines)").strong().heading());
+    ui.horizontal(|ui| {
+        ui.label(RichText::new("Daemon Logs (last 500 lines)").strong().heading());
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if ui.button("📂 Crash Reports").on_hover_text("Open folder with crash reports").clicked() {
+                let crash_dir = crate::app::get_crash_dir();
+                let _ = std::fs::create_dir_all(&crash_dir);
+                let _ = webbrowser::open(&crash_dir);
+            }
+        });
+    });
     ui.add_space(8.0);
 
     ui.horizontal(|ui| {
@@ -49,6 +58,14 @@ fn draw_logs_view(ui: &mut Ui, state: &mut AppState, ctx: &Context) {
                 .collect::<Vec<_>>()
                 .join("\n");
             ctx.output_mut(|o| o.copied_text = log_text);
+        }
+
+        if ui.button(if state.log_paused { "▶ Resume Output" } else { "⏸ Pause Output" }).clicked() {
+            state.log_paused = !state.log_paused;
+        }
+
+        if state.log_paused {
+            ui.label(RichText::new("Output Paused").color(egui::Color32::from_rgb(255, 200, 0)).strong());
         }
     });
 
@@ -68,18 +85,19 @@ fn draw_logs_view(ui: &mut Ui, state: &mut AppState, ctx: &Context) {
         .auto_shrink([false, false])
         .show(ui, |ui| {
             for entry in state.daemon_logs.iter().rev() {
-                let show = match entry.level.as_str() {
+                let level_upper = entry.level.to_uppercase();
+                let show = match level_upper.as_str() {
                     "ERROR" => state.log_filter_error,
-                    "WARN" => state.log_filter_warn,
+                    "WARN" | "WARNING" => state.log_filter_warn,
                     "INFO" => state.log_filter_info,
                     "DEBUG" | "TRACE" => state.log_filter_debug,
                     _ => true,
                 };
 
                 if show {
-                    let color = match entry.level.as_str() {
+                    let color = match level_upper.as_str() {
                         "ERROR" => egui::Color32::from_rgb(255, 100, 100),
-                        "WARN" => egui::Color32::from_rgb(255, 200, 100),
+                        "WARN" | "WARNING" => egui::Color32::from_rgb(255, 200, 100),
                         "DEBUG" | "TRACE" => egui::Color32::from_rgb(150, 150, 150),
                         _ => ui.visuals().text_color(),
                     };

--- a/gui/src/pages/settings.rs
+++ b/gui/src/pages/settings.rs
@@ -721,25 +721,25 @@ fn draw_hardware_info(ui: &mut Ui, state: &AppState) {
                     ui.label(format!("{:?}", gpu.gpu_type));
                     ui.end_row();
 
-                    if gpu.name.contains("NVIDIA") {
-                        if let Some(ref driver) = gpu.driver_version {
-                            ui.label("Driver Version:");
-                            ui.label(driver);
-                            ui.end_row();
-                        }
+                    if let Some(ref driver) = gpu.driver_version {
+                        ui.label("Driver Version:");
+                        ui.label(driver);
+                        ui.end_row();
+                    }
 
-                        if let Some(ref arch) = gpu.architecture {
-                            ui.label("Architecture:");
-                            ui.label(arch);
-                            ui.end_row();
-                        }
+                    if let Some(ref arch) = gpu.architecture {
+                        ui.label("Architecture:");
+                        ui.label(arch);
+                        ui.end_row();
+                    }
 
-                        if !gpu.supported_p_states.is_empty() {
-                            ui.label("Supported P-States:");
-                            ui.label(gpu.supported_p_states.join(", "));
-                            ui.end_row();
-                        }
+                    if !gpu.supported_p_states.is_empty() {
+                        ui.label("Supported P-States:");
+                        ui.label(gpu.supported_p_states.join(", "));
+                        ui.end_row();
+                    }
 
+                    if gpu.gpu_type == lapsphere_common::types::GpuType::Discrete {
                         ui.label("Power Limit Support:");
                         ui.label(if gpu.supports_power_limit { "✅ Supported" } else { "❌ Not Supported" });
                         ui.end_row();
@@ -749,30 +749,30 @@ fn draw_hardware_info(ui: &mut Ui, state: &AppState) {
                             ui.label(format!("{} - {} W", min, max));
                             ui.end_row();
                         }
+                    }
 
-                        if let Some(ref v_type) = gpu.vram_type {
-                            ui.label("VRAM Type:");
-                            ui.label(v_type);
-                            ui.end_row();
-                        }
+                    if let Some(ref v_type) = gpu.vram_type {
+                        ui.label("VRAM Type:");
+                        ui.label(v_type);
+                        ui.end_row();
+                    }
 
-                        if let Some(ref v_vendor) = gpu.vram_vendor {
-                            ui.label("VRAM Vendor:");
-                            ui.label(v_vendor);
-                            ui.end_row();
-                        }
+                    if let Some(ref v_vendor) = gpu.vram_vendor {
+                        ui.label("VRAM Vendor:");
+                        ui.label(v_vendor);
+                        ui.end_row();
+                    }
 
-                        if let Some(v_bus) = gpu.vram_bus_width {
-                            ui.label("Bus Width:");
-                            ui.label(format!("{}-bit", v_bus));
-                            ui.end_row();
-                        }
+                    if let Some(v_bus) = gpu.vram_bus_width {
+                        ui.label("Bus Width:");
+                        ui.label(format!("{}-bit", v_bus));
+                        ui.end_row();
+                    }
 
-                        if let Some(v_bw) = gpu.vram_bandwidth {
-                            ui.label("VRAM Bandwidth:");
-                            ui.label(format!("{:.1} GB/s", v_bw));
-                            ui.end_row();
-                        }
+                    if let Some(v_bw) = gpu.vram_bandwidth {
+                        ui.label("VRAM Bandwidth:");
+                        ui.label(format!("{:.1} GB/s", v_bw));
+                        ui.end_row();
                     }
                 });
 

--- a/gui/src/pages/settings.rs
+++ b/gui/src/pages/settings.rs
@@ -40,7 +40,7 @@ pub fn draw(ui: &mut Ui, state: &mut AppState, theme: &mut LapSphereTheme, ctx: 
 
 fn draw_logs_view(ui: &mut Ui, state: &mut AppState, ctx: &Context) {
     ui.horizontal(|ui| {
-        ui.label(RichText::new("Daemon Logs (last 500 lines)").strong().heading());
+        ui.label(RichText::new("Daemon Logs (last 1000 lines)").strong().heading());
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             if ui.button("📂 Crash Reports").on_hover_text("Open folder with crash reports").clicked() {
                 let crash_dir = crate::app::get_crash_dir();
@@ -72,7 +72,7 @@ fn draw_logs_view(ui: &mut Ui, state: &mut AppState, ctx: &Context) {
     ui.add_space(8.0);
 
     ui.horizontal(|ui| {
-        ui.label("Filter:");
+        ui.label("Filter Level:");
         ui.checkbox(&mut state.log_filter_error, "Error");
         ui.checkbox(&mut state.log_filter_warn, "Warning");
         ui.checkbox(&mut state.log_filter_info, "Info");
@@ -105,6 +105,7 @@ fn draw_logs_view(ui: &mut Ui, state: &mut AppState, ctx: &Context) {
                     ui.horizontal_top(|ui| {
                         ui.label(RichText::new(&entry.timestamp).weak().monospace());
                         ui.label(RichText::new(&entry.level).color(color).strong().monospace());
+                        ui.label(RichText::new(&entry.target).color(egui::Color32::from_rgb(100, 150, 255)).monospace());
                         ui.label(RichText::new(&entry.message).monospace());
                     });
                 }

--- a/gui/src/pages/statistics.rs
+++ b/gui/src/pages/statistics.rs
@@ -414,29 +414,6 @@ fn draw_gpu_info(ui: &mut Ui, state: &AppState) {
                                 ui.end_row();
                             }
 
-                            if let Some(ref v_type) = gpu.vram_type {
-                                ui.label("VRAM Type:");
-                                ui.label(v_type);
-                                ui.end_row();
-                            }
-
-                            if let Some(ref v_vendor) = gpu.vram_vendor {
-                                ui.label("VRAM Vendor:");
-                                ui.label(v_vendor);
-                                ui.end_row();
-                            }
-
-                            if let Some(v_bus) = gpu.vram_bus_width {
-                                ui.label("Bus Width:");
-                                ui.label(format!("{}-bit", v_bus));
-                                ui.end_row();
-                            }
-
-                            if let Some(v_bw) = gpu.vram_bandwidth {
-                                ui.label("VRAM Bandwidth:");
-                                ui.label(format!("{:.1} GB/s", v_bw));
-                                ui.end_row();
-                            }
 
 
                             if let Some(fo) = gpu.freq_offset {

--- a/gui/src/pages/statistics.rs
+++ b/gui/src/pages/statistics.rs
@@ -1,7 +1,6 @@
 use egui::{Ui, ScrollArea, CollapsingHeader, Grid, ProgressBar, RichText};
 use egui::Color32;
 use crate::app::AppState;
-use webbrowser;
 use crate::theme::{temp_color, load_color, power_color};
 
 pub const STATISTICS_SECTIONS: [(&str, &str); 8] = [
@@ -36,16 +35,7 @@ pub fn normalize_section_order(order: &[String]) -> Vec<String> {
 
 pub fn draw(ui: &mut Ui, state: &mut AppState) {
     ui.add_space(6.0);
-    ui.horizontal(|ui| {
-        ui.heading("📊 Statistics");
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            if ui.button("📂 Crash Reports").on_hover_text("Open folder with crash reports").clicked() {
-                let crash_dir = crate::app::get_crash_dir();
-                let _ = std::fs::create_dir_all(&crash_dir);
-                let _ = webbrowser::open(&crash_dir);
-            }
-        });
-    });
+    ui.heading("📊 Statistics");
     ui.add_space(6.0);
     ui.separator();
 

--- a/gui/src/pages/statistics.rs
+++ b/gui/src/pages/statistics.rs
@@ -414,6 +414,30 @@ fn draw_gpu_info(ui: &mut Ui, state: &AppState) {
                                 ui.end_row();
                             }
 
+                            if let Some(ref v_type) = gpu.vram_type {
+                                ui.label("VRAM Type:");
+                                ui.label(v_type);
+                                ui.end_row();
+                            }
+
+                            if let Some(ref v_vendor) = gpu.vram_vendor {
+                                ui.label("VRAM Vendor:");
+                                ui.label(v_vendor);
+                                ui.end_row();
+                            }
+
+                            if let Some(v_bus) = gpu.vram_bus_width {
+                                ui.label("Bus Width:");
+                                ui.label(format!("{}-bit", v_bus));
+                                ui.end_row();
+                            }
+
+                            if let Some(v_bw) = gpu.vram_bandwidth {
+                                ui.label("VRAM Bandwidth:");
+                                ui.label(format!("{:.1} GB/s", v_bw));
+                                ui.end_row();
+                            }
+
 
                             if let Some(fo) = gpu.freq_offset {
                                 ui.label("Freq Offset:");


### PR DESCRIPTION
This PR fixes a bug where the 'View logs' tab in Settings was empty by ensuring the daemon initializes the logger with a default 'Info' level. It also adds NVIDIA VRAM information (type, vendor, bus width, and bandwidth) to the main Statistics page and improves the general GPU info rendering logic.

---
*PR created automatically by Jules for task [18033069639029604129](https://jules.google.com/task/18033069639029604129) started by @weter11*