### PR TITLE
Rework GPU Overclocking for Real-time Core Feedback

### DIFF
--- a/daemon/src/dbus_interface.rs
+++ b/daemon/src/dbus_interface.rs
@@ -437,22 +437,6 @@ impl ControlInterface {
         )
     }
 
-    async fn set_memory_locked_clocks(&self, device_index: u32, min_clock: u32, max_clock: u32) -> Result<(), zbus::fdo::Error> {
-        log_api!(
-            "SetMemoryLockedClocks",
-            crate::hardware_control::set_memory_locked_clocks(device_index, min_clock, max_clock),
-            |_| format!("gpu={} min={} max={}", device_index, min_clock, max_clock)
-        )
-    }
-
-    async fn reset_memory_locked_clocks(&self, device_index: u32) -> Result<(), zbus::fdo::Error> {
-        log_api!(
-            "ResetMemoryLockedClocks",
-            crate::hardware_control::reset_memory_locked_clocks(device_index),
-            |_| format!("gpu={}", device_index)
-        )
-    }
-
     async fn reset_gpu_clocks(&self, device_index: u32) -> Result<(), zbus::fdo::Error> {
         log_api!(
             "ResetGpuClocks",
@@ -466,14 +450,6 @@ impl ControlInterface {
             "GetGpuClockRanges",
             crate::hardware_detection::get_gpu_clock_ranges(device_index),
             |i: &(u32, u32)| format!("gpu={} range={}..{}", device_index, i.0, i.1)
-        )
-    }
-
-    async fn get_gpu_mem_clock_ranges(&self, device_index: u32) -> Result<String, zbus::fdo::Error> {
-        log_api_json!(
-            "GetGpuMemClockRanges",
-            crate::hardware_detection::get_gpu_mem_clock_ranges(device_index),
-            |i: &Vec<u32>| format!("gpu={} count={}", device_index, i.len())
         )
     }
 

--- a/daemon/src/dbus_interface.rs
+++ b/daemon/src/dbus_interface.rs
@@ -172,6 +172,7 @@ impl ControlInterface {
             if profile.gpu_settings.manual_clocks {
                 crate::hardware_detection::record_gpu_tweak();
             }
+            crate::hardware_detection::record_gpu_save();
             crate::hardware_control::apply_profile(&profile)
         })().await;
 
@@ -433,6 +434,7 @@ impl ControlInterface {
     }
 
     async fn set_gpu_locked_clocks(&self, device_index: u32, min_clock: u32, max_clock: u32) -> Result<(), zbus::fdo::Error> {
+        crate::hardware_detection::record_gpu_tweak();
         log_api!(
             "SetGpuLockedClocks",
             crate::hardware_control::set_gpu_locked_clocks(device_index, min_clock, max_clock),
@@ -476,6 +478,7 @@ impl ControlInterface {
     }
 
     async fn set_gpu_power_limit(&self, device_index: u32, limit_watts: u32) -> Result<(), zbus::fdo::Error> {
+        crate::hardware_detection::record_gpu_tweak();
         log_api!(
             "SetGpuPowerLimit",
             crate::hardware_control::set_gpu_power_limit(device_index, limit_watts),

--- a/daemon/src/dbus_interface.rs
+++ b/daemon/src/dbus_interface.rs
@@ -169,10 +169,6 @@ impl ControlInterface {
                 let mut state = crate::GPU_DAEMON_STATE.lock().unwrap();
                 *state = Some(profile.gpu_settings.clone());
             }
-            if profile.gpu_settings.manual_clocks {
-                crate::hardware_detection::record_gpu_tweak();
-            }
-            crate::hardware_detection::record_gpu_save();
             crate::hardware_control::apply_profile(&profile)
         })().await;
 
@@ -434,7 +430,6 @@ impl ControlInterface {
     }
 
     async fn set_gpu_locked_clocks(&self, device_index: u32, min_clock: u32, max_clock: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_detection::record_gpu_tweak();
         log_api!(
             "SetGpuLockedClocks",
             crate::hardware_control::set_gpu_locked_clocks(device_index, min_clock, max_clock),
@@ -451,7 +446,6 @@ impl ControlInterface {
     }
 
     async fn get_gpu_clock_ranges(&self, device_index: u32) -> Result<String, zbus::fdo::Error> {
-        crate::hardware_detection::record_gpu_tweak();
         log_api_json!(
             "GetGpuClockRanges",
             crate::hardware_detection::get_gpu_clock_ranges(device_index),
@@ -460,7 +454,6 @@ impl ControlInterface {
     }
 
     async fn set_gpu_core_offset(&self, device_index: u32, offset: f32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_detection::record_gpu_tweak();
         log_api!(
             "SetGpuCoreOffset",
             crate::hardware_control::set_gpu_core_offset(device_index, offset),
@@ -469,7 +462,6 @@ impl ControlInterface {
     }
 
     async fn set_gpu_memory_offset(&self, device_index: u32, offset: f32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_detection::record_gpu_tweak();
         log_api!(
             "SetGpuMemoryOffset",
             crate::hardware_control::set_gpu_memory_offset(device_index, offset),
@@ -478,7 +470,6 @@ impl ControlInterface {
     }
 
     async fn set_gpu_power_limit(&self, device_index: u32, limit_watts: u32) -> Result<(), zbus::fdo::Error> {
-        crate::hardware_detection::record_gpu_tweak();
         log_api!(
             "SetGpuPowerLimit",
             crate::hardware_control::set_gpu_power_limit(device_index, limit_watts),

--- a/daemon/src/dbus_interface.rs
+++ b/daemon/src/dbus_interface.rs
@@ -169,6 +169,9 @@ impl ControlInterface {
                 let mut state = crate::GPU_DAEMON_STATE.lock().unwrap();
                 *state = Some(profile.gpu_settings.clone());
             }
+            if profile.gpu_settings.manual_clocks {
+                crate::hardware_detection::record_gpu_tweak();
+            }
             crate::hardware_control::apply_profile(&profile)
         })().await;
 
@@ -446,6 +449,7 @@ impl ControlInterface {
     }
 
     async fn get_gpu_clock_ranges(&self, device_index: u32) -> Result<String, zbus::fdo::Error> {
+        crate::hardware_detection::record_gpu_tweak();
         log_api_json!(
             "GetGpuClockRanges",
             crate::hardware_detection::get_gpu_clock_ranges(device_index),
@@ -454,6 +458,7 @@ impl ControlInterface {
     }
 
     async fn set_gpu_core_offset(&self, device_index: u32, offset: f32) -> Result<(), zbus::fdo::Error> {
+        crate::hardware_detection::record_gpu_tweak();
         log_api!(
             "SetGpuCoreOffset",
             crate::hardware_control::set_gpu_core_offset(device_index, offset),
@@ -462,6 +467,7 @@ impl ControlInterface {
     }
 
     async fn set_gpu_memory_offset(&self, device_index: u32, offset: f32) -> Result<(), zbus::fdo::Error> {
+        crate::hardware_detection::record_gpu_tweak();
         log_api!(
             "SetGpuMemoryOffset",
             crate::hardware_control::set_gpu_memory_offset(device_index, offset),

--- a/daemon/src/hardware_control.rs
+++ b/daemon/src/hardware_control.rs
@@ -448,19 +448,6 @@ pub fn set_gpu_locked_clocks(device_index: u32, min_clock: u32, max_clock: u32) 
     Ok(())
 }
 
-pub fn set_memory_locked_clocks(device_index: u32, min_clock: u32, max_clock: u32) -> Result<()> {
-    let nvml = get_nvml()?;
-    let mut device = nvml.device_by_index(device_index)?;
-    device.set_mem_locked_clocks(min_clock, max_clock)?;
-    Ok(())
-}
-
-pub fn reset_memory_locked_clocks(device_index: u32) -> Result<()> {
-    let nvml = get_nvml()?;
-    let mut device = nvml.device_by_index(device_index)?;
-    device.reset_mem_locked_clocks()?;
-    Ok(())
-}
 
 pub fn reset_gpu_clocks(device_index: u32) -> Result<()> {
     let nvml = get_nvml()?;

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -1413,28 +1413,44 @@ use nvml_wrapper::enum_wrappers::device::{Clock, PerformanceState};
 
 
 
-pub fn get_gpu_clock_ranges(device_index: u32) -> Result<(u32, u32)> {
-    let nvml = get_nvml()?;
-    let device = nvml.device_by_index(device_index)?;
-
-    // We specifically target P-State 0 for overclocking ranges
+/// Internal helper to get base (un-offset) GPU clock ranges for P-State 0
+fn get_base_gpu_clock_ranges(device: &nvml_wrapper::Device) -> Result<(u32, u32)> {
     match device.min_max_clock_of_pstate(Clock::Graphics, PerformanceState::Zero) {
         Ok((min, max)) => Ok((min, max)),
         Err(e) => {
             log::warn!(target: "hw.detect", "Failed to get P0 clock ranges via min_max_clock_of_pstate: {}. Using fallback.", e);
             // Fallback to absolute max supported clocks if P0 ranges fail
+            let mut fallback = None;
             if let Ok(mem_clocks) = device.supported_memory_clocks() {
                 if let Some(&target_mem_clock) = mem_clocks.iter().max() {
                     if let Ok(clocks) = device.supported_graphics_clocks(target_mem_clock) {
                         if let (Some(&c_min), Some(&c_max)) = (clocks.iter().min(), clocks.iter().max()) {
-                            return Ok((c_min, c_max));
+                            fallback = Some((c_min, c_max));
                         }
                     }
                 }
             }
-            Err(anyhow!("Could not determine graphics clock ranges for P-State 0"))
+            fallback.ok_or_else(|| anyhow!("Could not determine graphics clock ranges for P-State 0: {}", e))
         }
     }
+}
+
+pub fn get_gpu_clock_ranges(device_index: u32) -> Result<(u32, u32)> {
+    let nvml = get_nvml()?;
+    let device = nvml.device_by_index(device_index)?;
+
+    let (mut min, mut max) = get_base_gpu_clock_ranges(&device)?;
+
+    // Add current core offset if any to show real-time effective ranges in the UI
+    let offset = {
+        let map = crate::MANUAL_GPU_OFFSETS.lock().unwrap();
+        map.get(&device_index).map(|(c, _)| *c).unwrap_or(0.0)
+    };
+
+    min = (min as f32 + offset).max(0.0) as u32;
+    max = (max as f32 + offset).max(0.0) as u32;
+
+    Ok((min, max))
 }
 
 
@@ -1932,7 +1948,7 @@ fn get_nvidia_extended_stats(gpu_index: u32) -> (Option<f32>, Option<f32>, Optio
 }
 
 fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
-    let (manual_clocks_enabled, advanced_control_enabled) = {
+    let (manual_clocks_enabled, _advanced_control_enabled) = {
         let state = crate::GPU_DAEMON_STATE.lock().unwrap();
         state.as_ref().map_or((false, false), |s| (s.manual_clocks, s.advanced_control))
     };
@@ -2118,69 +2134,11 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
 
         // Check if we should skip this GPU to avoid waking it up
         // If manual clocks are disabled, we only poll if we haven't cached metadata yet
-        let metadata_cached = {
+        let _metadata_cached = {
             let cache = NVIDIA_METADATA_CACHE.lock().unwrap();
             cache.contains_key(&i)
         };
 
-        if !manual_clocks_enabled && metadata_cached {
-            let name = {
-                let cache = NVIDIA_NAMES_CACHE.lock().unwrap();
-                cache.get(i as usize).cloned().unwrap_or_else(|| "NVIDIA GPU".to_string())
-            };
-
-            let cached_metadata = {
-                let cache = NVIDIA_METADATA_CACHE.lock().unwrap();
-                cache.get(&i).cloned()
-            };
-
-            let (vram_type, vram_vendor, vram_bus_width, vram_bandwidth) =
-                if let Some(ref meta) = cached_metadata {
-                    let bandwidth = calculate_vram_bandwidth(meta.vram_type.as_ref(), meta.vram_bus_width, meta.memory_clock_range);
-                    (meta.vram_type.clone(), meta.vram_vendor.clone(), meta.vram_bus_width, bandwidth)
-                } else {
-                    (None, None, None, None)
-                };
-
-            gpus.push(GpuInfo {
-                name,
-                gpu_type: GpuType::Discrete,
-                status: status_from_sysfs.unwrap_or_else(|| "active".to_string()),
-                frequency: None,
-                memory_frequency: None,
-                temperature: None,
-                hotspot_temperature: None,
-                memory_temperature: None,
-                load: None,
-                power: None,
-                voltage: None,
-                freq_offset: None,
-                drain_offset: None,
-                power_offset: None,
-                total_offset: None,
-                min_core_clock: None,
-                max_core_clock: None,
-                min_memory_clock: None,
-                max_memory_clock: None,
-                core_clock_range: cached_metadata.as_ref().and_then(|m| m.core_clock_range),
-                memory_clock_range: cached_metadata.as_ref().and_then(|m| m.memory_clock_range),
-                is_desktop: false,
-                architecture: cached_metadata.as_ref().and_then(|m| m.architecture.clone()),
-                nvml_index: Some(i),
-                driver_version: driver_version.clone(),
-                supported_p_states: cached_metadata.as_ref().map(|m| m.supported_p_states.clone()).unwrap_or_default(),
-                supports_power_limit: cached_metadata.as_ref().and_then(|m| m.power_limit_range).is_some(),
-                power_limit_range: cached_metadata.as_ref().and_then(|m| m.power_limit_range),
-                supports_gpu_offset: cached_metadata.as_ref().map(|m| m.supports_gpu_offset).unwrap_or(false),
-                supports_mem_offset: cached_metadata.as_ref().map(|m| m.supports_mem_offset).unwrap_or(false),
-                fan_speed_range: None,
-                vram_type,
-                vram_vendor,
-                vram_bus_width,
-                vram_bandwidth,
-            });
-            continue;
-        }
 
         // Active GPU - proceed with NVML
         let device = match nvml.device_by_index(i) {
@@ -2256,9 +2214,9 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         // Logic:
         // 1. If manual control is OFF: poll if GPU is NOT suspended (for benchmarks)
         // 2. If manual control is ON:
-        //    - Poll if currently tweaking (wakes up GPU)
-        //    - Otherwise, poll only if in high-power state (P0-P4) and NOT suspended
-        //    - If in low-power (P5+) and NOT tweaking, stop polling to allow suspension
+        //    - Poll if currently tweaking (wakes up GPU and forces stats for a 20s window)
+        //    - Otherwise, follow the "show stats until sleep" rule: poll ONLY if in high-power state (P0-P4)
+        //      and NOT suspended. This allows it to drop to low-power and suspend when idle.
         let is_high_power = pstate_val <= 4;
         let should_poll_nvml = if !manual_clocks_enabled {
             !is_suspended
@@ -2266,7 +2224,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             is_tweaking || (is_high_power && !is_suspended)
         };
 
-        let should_poll_nvapi = is_high_power && (manual_clocks_enabled || advanced_control_enabled);
+        let should_poll_nvapi = is_high_power && should_poll_nvml;
 
         let (frequency, memory_frequency, temperature, load, power) = if !should_poll_nvml {
             (None, None, None, None, None)
@@ -2345,7 +2303,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 let minor_number = device.minor_number().unwrap_or(i);
                 let (vram_type, vram_vendor, vram_bus_width, _) = get_vram_info(minor_number);
 
-                let core_range = get_gpu_clock_ranges(i).ok();
+                let core_range = get_base_gpu_clock_ranges(&device).ok();
 
                 let mut mem_range = None;
                 if let Ok(supported_states) = device.supported_performance_states() {
@@ -2397,7 +2355,14 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         let v_type = metadata.vram_type;
         let v_vendor = metadata.vram_vendor;
         let v_bus = metadata.vram_bus_width;
-        let core_clock_range = metadata.core_clock_range;
+        // Apply current offset to the cached base range for real-time reporting
+        let core_clock_range = metadata.core_clock_range.map(|(min, max)| {
+            let offset = {
+                let map = crate::MANUAL_GPU_OFFSETS.lock().unwrap();
+                map.get(&i).map(|(c, _)| *c).unwrap_or(0.0)
+            };
+            ((min as f32 + offset).max(0.0) as u32, (max as f32 + offset).max(0.0) as u32)
+        });
         let memory_clock_range = metadata.memory_clock_range;
         let v_bw = calculate_vram_bandwidth(v_type.as_ref(), v_bus, memory_clock_range);
 

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -1398,46 +1398,26 @@ pub fn get_gpu_clock_ranges(device_index: u32) -> Result<(u32, u32)> {
     let nvml = get_nvml()?;
     let device = nvml.device_by_index(device_index)?;
 
-    let mut min_clock = u32::MAX;
-    let mut max_clock = 0;
-
-    // Iterate through all performance states to find absolute min/max
-    if let Ok(supported_states) = device.supported_performance_states() {
-        for pstate in supported_states {
-            if let Ok((p_min, p_max)) = device.min_max_clock_of_pstate(Clock::Graphics, pstate) {
-                if p_min < min_clock { min_clock = p_min; }
-                if p_max > max_clock { max_clock = p_max; }
-            }
-        }
-    }
-
-    // Fallback to supported_graphics_clocks if min_clock is still MAX
-    if min_clock == u32::MAX {
-        if let Ok(mem_clocks) = device.supported_memory_clocks() {
-            if let Some(&target_mem_clock) = mem_clocks.iter().max() {
-                if let Ok(clocks) = device.supported_graphics_clocks(target_mem_clock) {
-                    if let (Some(&c_min), Some(&c_max)) = (clocks.iter().min(), clocks.iter().max()) {
-                        min_clock = c_min;
-                        max_clock = c_max;
+    // We specifically target P-State 0 for overclocking ranges
+    match device.min_max_clock_of_pstate(Clock::Graphics, PerformanceState::Zero) {
+        Ok((min, max)) => Ok((min, max)),
+        Err(e) => {
+            log::warn!(target: "hw.detect", "Failed to get P0 clock ranges via min_max_clock_of_pstate: {}. Using fallback.", e);
+            // Fallback to absolute max supported clocks if P0 ranges fail
+            if let Ok(mem_clocks) = device.supported_memory_clocks() {
+                if let Some(&target_mem_clock) = mem_clocks.iter().max() {
+                    if let Ok(clocks) = device.supported_graphics_clocks(target_mem_clock) {
+                        if let (Some(&c_min), Some(&c_max)) = (clocks.iter().min(), clocks.iter().max()) {
+                            return Ok((c_min, c_max));
+                        }
                     }
                 }
             }
+            Err(anyhow!("Could not determine graphics clock ranges for P-State 0"))
         }
     }
-
-    if min_clock == u32::MAX {
-        return Err(anyhow!("Could not determine graphics clock ranges"));
-    }
-
-    Ok((min_clock, max_clock))
 }
 
-pub fn get_gpu_mem_clock_ranges(device_index: u32) -> Result<Vec<u32>> {
-    let nvml = get_nvml()?;
-    let device = nvml.device_by_index(device_index)?;
-    let clocks = device.supported_memory_clocks()?;
-    Ok(clocks)
-}
 
 pub fn get_gpu_core_offset_limits(device_index: u32) -> Result<(i32, i32)> {
     let nvml = get_nvml()?;

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -2289,8 +2289,32 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         let v_type = metadata.vram_type;
         let v_vendor = metadata.vram_vendor;
         let v_bus = metadata.vram_bus_width;
-        let core_clock_range = metadata.core_clock_range;
-        let memory_clock_range = metadata.memory_clock_range;
+        let core_clock_range = get_gpu_clock_ranges(i).ok();
+
+        let mut memory_clock_range = None;
+        if let Ok(supported_states) = device.supported_performance_states() {
+            let mut m_min = u32::MAX;
+            let mut m_max = 0;
+            for pstate in supported_states {
+                if let Ok((p_min, p_max)) = device.min_max_clock_of_pstate(Clock::Memory, pstate) {
+                    if p_min < m_min { m_min = p_min; }
+                    if p_max > m_max { m_max = p_max; }
+                }
+            }
+            if m_min != u32::MAX {
+                memory_clock_range = Some((m_min, m_max));
+            }
+        }
+
+        // Fallback for memory clock range
+        if memory_clock_range.is_none() {
+            if let Ok(clocks) = device.supported_memory_clocks() {
+                if let (Some(&c_min), Some(&c_max)) = (clocks.iter().min(), clocks.iter().max()) {
+                    memory_clock_range = Some((c_min, c_max));
+                }
+            }
+        }
+
         let v_bw = calculate_vram_bandwidth(v_type.as_ref(), v_bus, memory_clock_range);
 
         // Log VRAM info for diagnostics

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -44,8 +44,17 @@ static LAST_GPU_TWEAK_TIME: Lazy<Mutex<Instant>> = Lazy::new(|| {
     Mutex::new(Instant::now() - std::time::Duration::from_secs(3600))
 });
 
+static LAST_GPU_SAVE_TIME: Lazy<Mutex<Instant>> = Lazy::new(|| {
+    Mutex::new(Instant::now() - std::time::Duration::from_secs(3600))
+});
+
 pub fn record_gpu_tweak() {
     let mut last = LAST_GPU_TWEAK_TIME.lock().unwrap();
+    *last = Instant::now();
+}
+
+pub fn record_gpu_save() {
+    let mut last = LAST_GPU_SAVE_TIME.lock().unwrap();
     *last = Instant::now();
 }
 
@@ -1929,8 +1938,10 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
     };
 
     let is_tweaking = {
-        let last = LAST_GPU_TWEAK_TIME.lock().unwrap();
-        last.elapsed() < std::time::Duration::from_secs(30)
+        let tweak = LAST_GPU_TWEAK_TIME.lock().unwrap();
+        let save = LAST_GPU_SAVE_TIME.lock().unwrap();
+        // Tweaking is active for 20 seconds, BUT stops immediately if save was clicked after the last tweak
+        tweak.elapsed() < std::time::Duration::from_secs(20) && *save < *tweak
     };
 
     // 1. Check sysfs for NVIDIA devices and their status to avoid waking up suspended GPUs
@@ -2242,14 +2253,17 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         }).unwrap_or(0);
 
         // Determine if we should poll monitoring stats
-        // We only poll NVML if:
-        // 1. Manual clocks are enabled AND (Advanced control is on OR we are actively tweaking)
-        // 2. The GPU is in a high-power state (P0-P4), meaning it's already awake and in use
+        // Logic:
+        // 1. If manual control is OFF: poll if GPU is NOT suspended (for benchmarks)
+        // 2. If manual control is ON:
+        //    - Poll if currently tweaking (wakes up GPU)
+        //    - Otherwise, poll only if in high-power state (P0-P4) and NOT suspended
+        //    - If in low-power (P5+) and NOT tweaking, stop polling to allow suspension
         let is_high_power = pstate_val <= 4;
-        let should_poll_nvml = if advanced_control_enabled {
-            pstate_val <= 8
+        let should_poll_nvml = if !manual_clocks_enabled {
+            !is_suspended
         } else {
-            manual_clocks_enabled && (is_tweaking || is_high_power)
+            is_tweaking || (is_high_power && !is_suspended)
         };
 
         let should_poll_nvapi = is_high_power && (manual_clocks_enabled || advanced_control_enabled);

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -2132,14 +2132,6 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             continue;
         }
 
-        // Check if we should skip this GPU to avoid waking it up
-        // If manual clocks are disabled, we only poll if we haven't cached metadata yet
-        let _metadata_cached = {
-            let cache = NVIDIA_METADATA_CACHE.lock().unwrap();
-            cache.contains_key(&i)
-        };
-
-
         // Active GPU - proceed with NVML
         let device = match nvml.device_by_index(i) {
             Ok(d) => d,
@@ -2211,20 +2203,22 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         }).unwrap_or(0);
 
         // Determine if we should poll monitoring stats
-        // Logic:
-        // 1. If manual control is OFF: poll if GPU is NOT suspended (for benchmarks)
-        // 2. If manual control is ON:
-        //    - Poll if currently tweaking (wakes up GPU and forces stats for a 20s window)
-        //    - Otherwise, follow the "show stats until sleep" rule: poll ONLY if in high-power state (P0-P4)
-        //      and NOT suspended. This allows it to drop to low-power and suspend when idle.
-        let is_high_power = pstate_val <= 4;
-        let should_poll_nvml = if !manual_clocks_enabled {
-            !is_suspended
+        // Logic for all modes:
+        // 1. If suspended: poll nothing.
+        // 2. If P0-P5: poll NVML and NVAPI (all stats).
+        // 3. If P6+ (including P8): poll NVML only if:
+        //    - Manual control is OFF (benchmarking/monitoring)
+        //    - OR user is currently tweaking (real-time feedback)
+        // This ensures visibility while allowing the GPU to enter low-power states and eventually suspend when overclocked and idle.
+        let (should_poll_nvml, should_poll_nvapi) = if is_suspended {
+            (false, false)
+        } else if pstate_val <= 5 {
+            (true, true)
         } else {
-            is_tweaking || (is_high_power && !is_suspended)
+            // P6+, including P8
+            let poll_p8 = !manual_clocks_enabled || is_tweaking;
+            (poll_p8, false)
         };
-
-        let should_poll_nvapi = is_high_power && should_poll_nvml;
 
         let (frequency, memory_frequency, temperature, load, power) = if !should_poll_nvml {
             (None, None, None, None, None)
@@ -2422,14 +2416,12 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 gpu_info.freq_offset = Some(stats.freq_offset);
                 gpu_info.drain_offset = Some(stats.drain_offset);
                 gpu_info.power_offset = Some(stats.power_offset);
-                gpu_info.total_offset = Some(stats.total_offset);
+                // User requested NOT to show 'Total Offset' when manual control is enabled
+                gpu_info.total_offset = None;
             } else {
                 // Fallback to manual offsets if dynamic is not active
-                let manual_map = crate::MANUAL_GPU_OFFSETS.lock().unwrap();
-                if let Some(offsets) = manual_map.get(&i) {
-                    let core: f32 = offsets.0;
-                    gpu_info.total_offset = Some(core.round() as i32);
-                }
+                // User requested NOT to show 'Total Offset' when manual control is enabled
+                gpu_info.total_offset = None;
             }
         }
 

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -2205,19 +2205,19 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         // Determine if we should poll monitoring stats
         // Logic for all modes:
         // 1. If suspended: poll nothing.
-        // 2. If P0-P5: poll NVML and NVAPI (all stats).
-        // 3. If P6+ (including P8): poll NVML only if:
+        // 2. If P0-P3: poll NVML and NVAPI (all stats).
+        // 3. If P4+ (including P8): poll NVML only if:
         //    - Manual control is OFF (benchmarking/monitoring)
         //    - OR user is currently tweaking (real-time feedback)
         // This ensures visibility while allowing the GPU to enter low-power states and eventually suspend when overclocked and idle.
         let (should_poll_nvml, should_poll_nvapi) = if is_suspended {
             (false, false)
-        } else if pstate_val <= 5 {
+        } else if pstate_val <= 3 {
             (true, true)
         } else {
-            // P6+, including P8
-            let poll_p8 = !manual_clocks_enabled || is_tweaking;
-            (poll_p8, false)
+            // P4+, including P8
+            let poll_low_power = !manual_clocks_enabled || is_tweaking;
+            (poll_low_power, false)
         };
 
         let (frequency, memory_frequency, temperature, load, power) = if !should_poll_nvml {
@@ -2416,12 +2416,14 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 gpu_info.freq_offset = Some(stats.freq_offset);
                 gpu_info.drain_offset = Some(stats.drain_offset);
                 gpu_info.power_offset = Some(stats.power_offset);
-                // User requested NOT to show 'Total Offset' when manual control is enabled
-                gpu_info.total_offset = None;
+                gpu_info.total_offset = Some(stats.total_offset);
             } else {
                 // Fallback to manual offsets if dynamic is not active
-                // User requested NOT to show 'Total Offset' when manual control is enabled
-                gpu_info.total_offset = None;
+                let manual_map = crate::MANUAL_GPU_OFFSETS.lock().unwrap();
+                if let Some(offsets) = manual_map.get(&i) {
+                    let core: f32 = offsets.0;
+                    gpu_info.total_offset = Some(core.round() as i32);
+                }
             }
         }
 

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -39,6 +39,16 @@ struct NvidiaMetadata {
 static NVIDIA_METADATA_CACHE: Lazy<Mutex<HashMap<u32, NvidiaMetadata>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
+static LAST_GPU_TWEAK_TIME: Lazy<Mutex<Instant>> = Lazy::new(|| {
+    // Initialize to 1 hour ago so it doesn't trigger immediately
+    Mutex::new(Instant::now() - std::time::Duration::from_secs(3600))
+});
+
+pub fn record_gpu_tweak() {
+    let mut last = LAST_GPU_TWEAK_TIME.lock().unwrap();
+    *last = Instant::now();
+}
+
 const BITS_PER_BYTE: f64 = 8.0;
 const BITS_PER_MEGABIT: f64 = 1_000_000.0;
 
@@ -1913,6 +1923,16 @@ fn get_nvidia_extended_stats(gpu_index: u32) -> (Option<f32>, Option<f32>, Optio
 }
 
 fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
+    let (manual_clocks_enabled, advanced_control_enabled) = {
+        let state = crate::GPU_DAEMON_STATE.lock().unwrap();
+        state.as_ref().map_or((false, false), |s| (s.manual_clocks, s.advanced_control))
+    };
+
+    let is_tweaking = {
+        let last = LAST_GPU_TWEAK_TIME.lock().unwrap();
+        last.elapsed() < std::time::Duration::from_secs(30)
+    };
+
     // 1. Check sysfs for NVIDIA devices and their status to avoid waking up suspended GPUs
     let mut nvidia_pci_ids = Vec::new();
     if let Ok(entries) = fs::read_dir("/sys/bus/pci/drivers/nvidia") {
@@ -2085,6 +2105,72 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             continue;
         }
 
+        // Check if we should skip this GPU to avoid waking it up
+        // If manual clocks are disabled, we only poll if we haven't cached metadata yet
+        let metadata_cached = {
+            let cache = NVIDIA_METADATA_CACHE.lock().unwrap();
+            cache.contains_key(&i)
+        };
+
+        if !manual_clocks_enabled && metadata_cached {
+            let name = {
+                let cache = NVIDIA_NAMES_CACHE.lock().unwrap();
+                cache.get(i as usize).cloned().unwrap_or_else(|| "NVIDIA GPU".to_string())
+            };
+
+            let cached_metadata = {
+                let cache = NVIDIA_METADATA_CACHE.lock().unwrap();
+                cache.get(&i).cloned()
+            };
+
+            let (vram_type, vram_vendor, vram_bus_width, vram_bandwidth) =
+                if let Some(ref meta) = cached_metadata {
+                    let bandwidth = calculate_vram_bandwidth(meta.vram_type.as_ref(), meta.vram_bus_width, meta.memory_clock_range);
+                    (meta.vram_type.clone(), meta.vram_vendor.clone(), meta.vram_bus_width, bandwidth)
+                } else {
+                    (None, None, None, None)
+                };
+
+            gpus.push(GpuInfo {
+                name,
+                gpu_type: GpuType::Discrete,
+                status: status_from_sysfs.unwrap_or_else(|| "active".to_string()),
+                frequency: None,
+                memory_frequency: None,
+                temperature: None,
+                hotspot_temperature: None,
+                memory_temperature: None,
+                load: None,
+                power: None,
+                voltage: None,
+                freq_offset: None,
+                drain_offset: None,
+                power_offset: None,
+                total_offset: None,
+                min_core_clock: None,
+                max_core_clock: None,
+                min_memory_clock: None,
+                max_memory_clock: None,
+                core_clock_range: cached_metadata.as_ref().and_then(|m| m.core_clock_range),
+                memory_clock_range: cached_metadata.as_ref().and_then(|m| m.memory_clock_range),
+                is_desktop: false,
+                architecture: cached_metadata.as_ref().and_then(|m| m.architecture.clone()),
+                nvml_index: Some(i),
+                driver_version: driver_version.clone(),
+                supported_p_states: cached_metadata.as_ref().map(|m| m.supported_p_states.clone()).unwrap_or_default(),
+                supports_power_limit: cached_metadata.as_ref().and_then(|m| m.power_limit_range).is_some(),
+                power_limit_range: cached_metadata.as_ref().and_then(|m| m.power_limit_range),
+                supports_gpu_offset: cached_metadata.as_ref().map(|m| m.supports_gpu_offset).unwrap_or(false),
+                supports_mem_offset: cached_metadata.as_ref().map(|m| m.supports_mem_offset).unwrap_or(false),
+                fan_speed_range: None,
+                vram_type,
+                vram_vendor,
+                vram_bus_width,
+                vram_bandwidth,
+            });
+            continue;
+        }
+
         // Active GPU - proceed with NVML
         let device = match nvml.device_by_index(i) {
             Ok(d) => d,
@@ -2156,9 +2242,17 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         }).unwrap_or(0);
 
         // Determine if we should poll monitoring stats
-        // NVML stats up to P8, skip NVAPI if P5 or higher
-        let should_poll_nvml = pstate_val <= 8;
-        let should_poll_nvapi = pstate_val <= 4;
+        // We only poll NVML if:
+        // 1. Manual clocks are enabled AND (Advanced control is on OR we are actively tweaking)
+        // 2. The GPU is in a high-power state (P0-P4), meaning it's already awake and in use
+        let is_high_power = pstate_val <= 4;
+        let should_poll_nvml = if advanced_control_enabled {
+            pstate_val <= 8
+        } else {
+            manual_clocks_enabled && (is_tweaking || is_high_power)
+        };
+
+        let should_poll_nvapi = is_high_power && (manual_clocks_enabled || advanced_control_enabled);
 
         let (frequency, memory_frequency, temperature, load, power) = if !should_poll_nvml {
             (None, None, None, None, None)
@@ -2289,32 +2383,8 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         let v_type = metadata.vram_type;
         let v_vendor = metadata.vram_vendor;
         let v_bus = metadata.vram_bus_width;
-        let core_clock_range = get_gpu_clock_ranges(i).ok();
-
-        let mut memory_clock_range = None;
-        if let Ok(supported_states) = device.supported_performance_states() {
-            let mut m_min = u32::MAX;
-            let mut m_max = 0;
-            for pstate in supported_states {
-                if let Ok((p_min, p_max)) = device.min_max_clock_of_pstate(Clock::Memory, pstate) {
-                    if p_min < m_min { m_min = p_min; }
-                    if p_max > m_max { m_max = p_max; }
-                }
-            }
-            if m_min != u32::MAX {
-                memory_clock_range = Some((m_min, m_max));
-            }
-        }
-
-        // Fallback for memory clock range
-        if memory_clock_range.is_none() {
-            if let Ok(clocks) = device.supported_memory_clocks() {
-                if let (Some(&c_min), Some(&c_max)) = (clocks.iter().min(), clocks.iter().max()) {
-                    memory_clock_range = Some((c_min, c_max));
-                }
-            }
-        }
-
+        let core_clock_range = metadata.core_clock_range;
+        let memory_clock_range = metadata.memory_clock_range;
         let v_bw = calculate_vram_bandwidth(v_type.as_ref(), v_bus, memory_clock_range);
 
         // Log VRAM info for diagnostics
@@ -2367,7 +2437,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         };
 
         // Fill in offsets if they exist in global state (assuming first NVIDIA GPU for now)
-        if name.to_lowercase().contains("nvidia") {
+        if name.to_lowercase().contains("nvidia") && manual_clocks_enabled {
             let stats_lock = crate::CURRENT_GPU_OVERCLOCK_STATS.lock().unwrap();
             if let Some(ref stats) = *stats_lock {
                 gpu_info.freq_offset = Some(stats.freq_offset);

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -39,25 +39,6 @@ struct NvidiaMetadata {
 static NVIDIA_METADATA_CACHE: Lazy<Mutex<HashMap<u32, NvidiaMetadata>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
-static LAST_GPU_TWEAK_TIME: Lazy<Mutex<Instant>> = Lazy::new(|| {
-    // Initialize to 1 hour ago so it doesn't trigger immediately
-    Mutex::new(Instant::now() - std::time::Duration::from_secs(3600))
-});
-
-static LAST_GPU_SAVE_TIME: Lazy<Mutex<Instant>> = Lazy::new(|| {
-    Mutex::new(Instant::now() - std::time::Duration::from_secs(3600))
-});
-
-pub fn record_gpu_tweak() {
-    let mut last = LAST_GPU_TWEAK_TIME.lock().unwrap();
-    *last = Instant::now();
-}
-
-pub fn record_gpu_save() {
-    let mut last = LAST_GPU_SAVE_TIME.lock().unwrap();
-    *last = Instant::now();
-}
-
 const BITS_PER_BYTE: f64 = 8.0;
 const BITS_PER_MEGABIT: f64 = 1_000_000.0;
 
@@ -1953,13 +1934,6 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         state.as_ref().map_or((false, false), |s| (s.manual_clocks, s.advanced_control))
     };
 
-    let is_tweaking = {
-        let tweak = LAST_GPU_TWEAK_TIME.lock().unwrap();
-        let save = LAST_GPU_SAVE_TIME.lock().unwrap();
-        // Tweaking is active for 20 seconds, BUT stops immediately if save was clicked after the last tweak
-        tweak.elapsed() < std::time::Duration::from_secs(20) && *save < *tweak
-    };
-
     // 1. Check sysfs for NVIDIA devices and their status to avoid waking up suspended GPUs
     let mut nvidia_pci_ids = Vec::new();
     if let Ok(entries) = fs::read_dir("/sys/bus/pci/drivers/nvidia") {
@@ -2206,18 +2180,16 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         // Logic for all modes:
         // 1. If suspended: poll nothing.
         // 2. If P0-P3: poll NVML and NVAPI (all stats).
-        // 3. If P4+ (including P8): poll NVML only if:
-        //    - Manual control is OFF (benchmarking/monitoring)
-        //    - OR user is currently tweaking (real-time feedback)
-        // This ensures visibility while allowing the GPU to enter low-power states and eventually suspend when overclocked and idle.
+        // 3. If P4+ (including P8): poll NVML only (no NVAPI/direct ioctls).
+        // This ensures visibility (P0-P3) while allowing the GPU to enter
+        // low-power states (P8) and eventually suspend.
         let (should_poll_nvml, should_poll_nvapi) = if is_suspended {
             (false, false)
         } else if pstate_val <= 3 {
             (true, true)
         } else {
             // P4+, including P8
-            let poll_low_power = !manual_clocks_enabled || is_tweaking;
-            (poll_low_power, false)
+            (true, false)
         };
 
         let (frequency, memory_frequency, temperature, load, power) = if !should_poll_nvml {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -427,8 +427,38 @@ fn apply_fan_curves(io: &tuxedo_io::TuxedoIo, settings: &FanSettings, sorted_cur
 }
 
 fn apply_gpu_overclocking(gpu_settings: &lapsphere_common::types::GpuSettings) -> Result<()> {
+    // Clear stats and last offset if advanced control or manual clocks are disabled
+    if !gpu_settings.advanced_control || !gpu_settings.manual_clocks {
+        {
+            let mut stats = CURRENT_GPU_OVERCLOCK_STATS.lock().unwrap();
+            *stats = None;
+        }
+        {
+            let mut last = LAST_APPLIED_OFFSET.lock().unwrap();
+            *last = None;
+        }
+        if !gpu_settings.manual_clocks {
+            // Only clear if not already cleared to avoid waking up GPU unnecessarily
+            let needs_clear = {
+                let map = MANUAL_GPU_OFFSETS.lock().unwrap();
+                map.get(&0).map_or(true, |offsets| offsets.0 != 0.0 || offsets.1 != 0.0)
+            };
+
+            if needs_clear {
+                log::info!("Manual clocks disabled, resetting GPU offsets to 0");
+                let _ = crate::hardware_control::set_gpu_core_offset(0, 0.0);
+                let _ = crate::hardware_control::set_gpu_memory_offset(0, 0.0);
+                {
+                    let mut map = MANUAL_GPU_OFFSETS.lock().unwrap();
+                    map.insert(0, (0.0, 0.0));
+                }
+            }
+        }
+        return Ok(());
+    }
+
     // 1. Get current GPU stats (temperature, power, frequency)
-    // We do this first to check for suspension
+    // We only do this if advanced control is enabled
     let gpus = crate::hardware_detection::get_gpu_info()?;
     let nvidia_gpu = gpus.iter().find(|g| g.name.to_lowercase().contains("nvidia"));
 
@@ -437,38 +467,8 @@ fn apply_gpu_overclocking(gpu_settings: &lapsphere_common::types::GpuSettings) -
         let is_suspended = status_lower.contains("suspended");
         let is_pstate = status_lower.starts_with('p');
 
-        // If suspended, don't do anything (definitely don't call NVML)
+        // If suspended, don't do anything
         if is_suspended {
-            return Ok(());
-        }
-
-        // Clear stats and last offset if advanced control or manual clocks are disabled
-        if !gpu_settings.advanced_control || !gpu_settings.manual_clocks {
-            {
-                let mut stats = CURRENT_GPU_OVERCLOCK_STATS.lock().unwrap();
-                *stats = None;
-            }
-            {
-                let mut last = LAST_APPLIED_OFFSET.lock().unwrap();
-                *last = None;
-            }
-            if !gpu_settings.manual_clocks {
-                // Only clear if not already cleared to avoid waking up GPU unnecessarily
-                let needs_clear = {
-                    let map = MANUAL_GPU_OFFSETS.lock().unwrap();
-                    map.get(&0).map_or(true, |offsets| offsets.0 != 0.0 || offsets.1 != 0.0)
-                };
-
-                if needs_clear {
-                    log::info!("Manual clocks disabled, resetting GPU offsets to 0");
-                    let _ = crate::hardware_control::set_gpu_core_offset(0, 0.0);
-                    let _ = crate::hardware_control::set_gpu_memory_offset(0, 0.0);
-                    {
-                        let mut map = MANUAL_GPU_OFFSETS.lock().unwrap();
-                        map.insert(0, (0.0, 0.0));
-                    }
-                }
-            }
             return Ok(());
         }
 

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -200,6 +200,9 @@ pub struct LapSphereApp {
     shortcuts: KeyboardShortcuts,
 
     startup_frames: u32,
+
+    last_tray_profile: String,
+    last_tray_profiles_count: usize,
 }
 
 #[derive(Debug)]
@@ -452,6 +455,9 @@ impl LapSphereApp {
             }
         };
         
+        let last_tray_profile = state.config.current_profile.clone();
+        let last_tray_profiles_count = state.config.profiles.len();
+
         Self {
             state,
             dbus_client,
@@ -462,6 +468,8 @@ impl LapSphereApp {
             hw_update_rx,
             shortcuts: KeyboardShortcuts::new(),
             startup_frames: 10,
+            last_tray_profile,
+            last_tray_profiles_count,
         }
     }
     
@@ -661,6 +669,21 @@ impl LapSphereApp {
         let Some(tray) = self.system_tray.as_mut() else {
             return;
         };
+
+        // Sync profile list if count changed
+        if self.state.config.profiles.len() != self.last_tray_profiles_count {
+            tray.set_profiles(&self.state.config.profiles);
+            self.last_tray_profiles_count = self.state.config.profiles.len();
+            // Force current profile sync as well since menu rebuilt
+            tray.set_current_profile(&self.state.config.current_profile);
+            self.last_tray_profile = self.state.config.current_profile.clone();
+        }
+
+        // Sync current profile if changed in main window
+        if self.state.config.current_profile != self.last_tray_profile {
+            tray.set_current_profile(&self.state.config.current_profile);
+            self.last_tray_profile = self.state.config.current_profile.clone();
+        }
 
         if let Some(event) = tray.handle_events() {
             match event {

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -218,7 +218,6 @@ pub enum HardwareUpdate {
     DaemonLogs(Vec<LogEntry>),
     UpdateInfo(String, String),
     GpuClockRanges(Result<(u32, u32), String>),
-    GpuMemClockRanges(Result<Vec<u32>, String>),
     GpuCoreOffsetLimits(Result<(i32, i32), String>),
     GpuMemOffsetLimits(Result<(i32, i32), String>),
     AvailableThresholds(Vec<u8>, Vec<u8>),
@@ -516,17 +515,6 @@ impl LapSphereApp {
                     match result {
                         Ok(ranges) => self.state.gpu_clock_ranges = Some(ranges),
                         Err(e) => self.state.show_message(format!("Failed to get GPU clock ranges: {}", e), true),
-                    }
-                }
-                HardwareUpdate::GpuMemClockRanges(result) => {
-                    match result {
-                        Ok(mut ranges) => {
-                            if !ranges.is_empty() {
-                                ranges.sort_unstable();
-                                self.state.gpu_mem_clock_ranges = Some((*ranges.first().unwrap(), *ranges.last().unwrap()));
-                            }
-                        },
-                        Err(e) => self.state.show_message(format!("Failed to get GPU memory clock ranges: {}", e), true),
                     }
                 }
                 HardwareUpdate::GpuCoreOffsetLimits(result) => {

--- a/gui/src/dbus_client.rs
+++ b/gui/src/dbus_client.rs
@@ -33,9 +33,6 @@ pub enum DbusCommand {
     SetGpuLockedClocks { device_index: u32, min_clock: u32, max_clock: u32, reply: oneshot::Sender<Result<()>> },
     ResetGpuClocks { device_index: u32, reply: oneshot::Sender<Result<()>> },
     GetGpuClockRanges { device_index: u32, reply: oneshot::Sender<Result<(u32, u32)>> },
-    GetGpuMemClockRanges { device_index: u32, reply: oneshot::Sender<Result<Vec<u32>>> },
-    SetMemoryLockedClocks { device_index: u32, min_clock: u32, max_clock: u32, reply: oneshot::Sender<Result<()>> },
-    ResetMemoryLockedClocks { device_index: u32, reply: oneshot::Sender<Result<()>> },
     SetGpuCoreOffset { device_index: u32, offset: f32, reply: oneshot::Sender<Result<()>> },
     SetGpuMemoryOffset { device_index: u32, offset: f32, reply: oneshot::Sender<Result<()>> },
     GetGpuCoreOffsetLimits { device_index: u32, reply: oneshot::Sender<Result<(i32, i32)>> },
@@ -208,24 +205,6 @@ impl DbusClient {
     pub fn get_gpu_clock_ranges(&self, device_index: u32) -> oneshot::Receiver<Result<(u32, u32)>> {
         let (tx, rx) = oneshot::channel();
         let _ = self.command_tx.send(DbusCommand::GetGpuClockRanges { device_index, reply: tx });
-        rx
-    }
-
-    pub fn get_gpu_mem_clock_ranges(&self, device_index: u32) -> oneshot::Receiver<Result<Vec<u32>>> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self.command_tx.send(DbusCommand::GetGpuMemClockRanges { device_index, reply: tx });
-        rx
-    }
-
-    pub fn set_memory_locked_clocks(&self, device_index: u32, min_clock: u32, max_clock: u32) -> oneshot::Receiver<Result<()>> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self.command_tx.send(DbusCommand::SetMemoryLockedClocks { device_index, min_clock, max_clock, reply: tx });
-        rx
-    }
-
-    pub fn reset_memory_locked_clocks(&self, device_index: u32) -> oneshot::Receiver<Result<()>> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self.command_tx.send(DbusCommand::ResetMemoryLockedClocks { device_index, reply: tx });
         rx
     }
 
@@ -463,24 +442,6 @@ async fn dbus_worker(mut command_rx: mpsc::UnboundedReceiver<DbusCommand>) -> Re
                 }
                 DbusCommand::GetGpuClockRanges { device_index, reply } => {
                     let result = get_gpu_clock_ranges_impl(&connection, device_index).await;
-                    let is_err = result.is_err();
-                    let _ = reply.send(result);
-                    if is_err { Err(anyhow::anyhow!("DBus call failed")) } else { Ok(()) }
-                }
-                DbusCommand::GetGpuMemClockRanges { device_index, reply } => {
-                    let result = get_gpu_mem_clock_ranges_impl(&connection, device_index).await;
-                    let is_err = result.is_err();
-                    let _ = reply.send(result);
-                    if is_err { Err(anyhow::anyhow!("DBus call failed")) } else { Ok(()) }
-                }
-                DbusCommand::SetMemoryLockedClocks { device_index, min_clock, max_clock, reply } => {
-                    let result = set_memory_locked_clocks_impl(&connection, device_index, min_clock, max_clock).await;
-                    let is_err = result.is_err();
-                    let _ = reply.send(result);
-                    if is_err { Err(anyhow::anyhow!("DBus call failed")) } else { Ok(()) }
-                }
-                DbusCommand::ResetMemoryLockedClocks { device_index, reply } => {
-                    let result = reset_memory_locked_clocks_impl(&connection, device_index).await;
                     let is_err = result.is_err();
                     let _ = reply.send(result);
                     if is_err { Err(anyhow::anyhow!("DBus call failed")) } else { Ok(()) }
@@ -866,39 +827,6 @@ async fn get_gpu_clock_ranges_impl(conn: &Connection, device_index: u32) -> Resu
     ).await?;
     let json: String = proxy.call("GetGpuClockRanges", &(device_index,)).await?;
     Ok(serde_json::from_str(&json)?)
-}
-
-async fn get_gpu_mem_clock_ranges_impl(conn: &Connection, device_index: u32) -> Result<Vec<u32>> {
-    let proxy = zbus::Proxy::new(
-        conn,
-        "io.lapsphere.Control",
-        "/io/lapsphere/Control",
-        "io.lapsphere.Control",
-    ).await?;
-    let json: String = proxy.call("GetGpuMemClockRanges", &(device_index,)).await?;
-    Ok(serde_json::from_str(&json)?)
-}
-
-async fn set_memory_locked_clocks_impl(conn: &Connection, device_index: u32, min_clock: u32, max_clock: u32) -> Result<()> {
-    let proxy = zbus::Proxy::new(
-        conn,
-        "io.lapsphere.Control",
-        "/io/lapsphere/Control",
-        "io.lapsphere.Control",
-    ).await?;
-    proxy.call::<_, _, ()>("SetMemoryLockedClocks", &(device_index, min_clock, max_clock)).await?;
-    Ok(())
-}
-
-async fn reset_memory_locked_clocks_impl(conn: &Connection, device_index: u32) -> Result<()> {
-    let proxy = zbus::Proxy::new(
-        conn,
-        "io.lapsphere.Control",
-        "/io/lapsphere/Control",
-        "io.lapsphere.Control",
-    ).await?;
-    proxy.call::<_, _, ()>("ResetMemoryLockedClocks", &(device_index,)).await?;
-    Ok(())
 }
 
 async fn set_gpu_core_offset_impl(conn: &Connection, device_index: u32, offset: f32) -> Result<()> {

--- a/gui/src/pages/tuning.rs
+++ b/gui/src/pages/tuning.rs
@@ -545,6 +545,9 @@ fn draw_gpu_tuning(
                 None,
                 state.gpu_mem_offset_limits,
                 nvidia_gpu_ref.as_ref(),
+                dbus_client,
+                hw_update_tx.clone(),
+                nvml_index,
             );
             if gpu_oc_poll != state.config.statistics_sections.gpu_overclock_poll_rate {
                 state.config.statistics_sections.gpu_overclock_poll_rate = gpu_oc_poll;
@@ -635,6 +638,14 @@ fn draw_gpu_standard_controls(
                 if min_gpu_clock > max_gpu_clock {
                     max_gpu_clock = min_gpu_clock;
                 }
+                if let Some(client) = dbus_client {
+                    let client_c = client.clone();
+                    let min = min_gpu_clock;
+                    let max = max_gpu_clock;
+                    tokio::spawn(async move {
+                        let _ = client_c.set_gpu_locked_clocks(nvml_index, min, max).await;
+                    });
+                }
             }
         });
 
@@ -643,6 +654,14 @@ fn draw_gpu_standard_controls(
             if ui.add(Slider::new(&mut max_gpu_clock, min_range..=max_range).suffix(" MHz")).changed() {
                 if max_gpu_clock < min_gpu_clock {
                     min_gpu_clock = max_gpu_clock;
+                }
+                if let Some(client) = dbus_client {
+                    let client_c = client.clone();
+                    let min = min_gpu_clock;
+                    let max = max_gpu_clock;
+                    tokio::spawn(async move {
+                        let _ = client_c.set_gpu_locked_clocks(nvml_index, min, max).await;
+                    });
                 }
             }
         });
@@ -660,7 +679,15 @@ fn draw_gpu_standard_controls(
         ui.label(RichText::new("GPU Memory Offset:").strong());
         if let Some((min_limit, max_limit)) = gpu_mem_offset_limits {
             let mut memory_offset = profile.gpu_settings.memory_offset.unwrap_or(0.0);
-            ui.add(Slider::new(&mut memory_offset, (min_limit as f32)..=(max_limit as f32)).suffix(" MHz"));
+            if ui.add(Slider::new(&mut memory_offset, (min_limit as f32)..=(max_limit as f32)).suffix(" MHz")).changed() {
+                if let Some(client) = dbus_client {
+                    let client_c = client.clone();
+                    let offset = memory_offset;
+                    tokio::spawn(async move {
+                        let _ = client_c.set_gpu_memory_offset(nvml_index, offset).await;
+                    });
+                }
+            }
             profile.gpu_settings.memory_offset = Some(memory_offset);
         } else {
             ui.label("Fetching GPU memory offset limits...");
@@ -675,7 +702,15 @@ fn draw_gpu_standard_controls(
         ui.label(RichText::new("GPU Power Limit:").strong());
         if let Some((min_w, max_w)) = gpu_info.power_limit_range {
             let mut power_limit = profile.gpu_settings.power_limit.unwrap_or(max_w);
-            ui.add(Slider::new(&mut power_limit, min_w..=max_w).suffix(" W"));
+            if ui.add(Slider::new(&mut power_limit, min_w..=max_w).suffix(" W")).changed() {
+                if let Some(client) = dbus_client {
+                    let client_c = client.clone();
+                    let limit = power_limit;
+                    tokio::spawn(async move {
+                        let _ = client_c.set_gpu_power_limit(nvml_index, limit).await;
+                    });
+                }
+            }
             profile.gpu_settings.power_limit = Some(power_limit);
         } else {
             ui.label("Could not determine power limit range.");
@@ -692,6 +727,9 @@ fn draw_gpu_advanced_controls(
     _gpu_mem_clock_ranges: Option<(u32, u32)>,
     gpu_mem_offset_limits: Option<(i32, i32)>,
     gpu_info: Option<&lapsphere_common::types::GpuInfo>,
+    dbus_client: Option<&DbusClient>,
+    hw_update_tx: tokio::sync::mpsc::UnboundedSender<crate::app::HardwareUpdate>,
+    nvml_index: u32,
 ) {
     ui.add_space(6.0);
     ui.label(RichText::new("GPU Locked Clocks (Advanced):").strong());
@@ -704,6 +742,19 @@ fn draw_gpu_advanced_controls(
                     if min_gpu_clock > max_gpu_clock {
                         max_gpu_clock = min_gpu_clock;
                     }
+                    if let Some(client) = dbus_client {
+                        let client_c = client.clone();
+                        let tx_c = hw_update_tx.clone();
+                        let min = min_gpu_clock;
+                        let max = max_gpu_clock;
+                        tokio::spawn(async move {
+                            let _ = client_c.set_gpu_locked_clocks(nvml_index, min, max).await;
+                            let res = client_c.get_gpu_clock_ranges(nvml_index).await
+                                .map(|r| r.map_err(|e| e.to_string()))
+                                .unwrap_or_else(|e| Err(e.to_string()));
+                            let _ = tx_c.send(crate::app::HardwareUpdate::GpuClockRanges(res));
+                        });
+                    }
                 }
             });
             ui.horizontal(|ui| {
@@ -711,6 +762,19 @@ fn draw_gpu_advanced_controls(
                 if ui.add(Slider::new(&mut max_gpu_clock, min_range..=max_range).suffix(" MHz")).changed() {
                     if max_gpu_clock < min_gpu_clock {
                         min_gpu_clock = max_gpu_clock;
+                    }
+                    if let Some(client) = dbus_client {
+                        let client_c = client.clone();
+                        let tx_c = hw_update_tx.clone();
+                        let min = min_gpu_clock;
+                        let max = max_gpu_clock;
+                        tokio::spawn(async move {
+                            let _ = client_c.set_gpu_locked_clocks(nvml_index, min, max).await;
+                            let res = client_c.get_gpu_clock_ranges(nvml_index).await
+                                .map(|r| r.map_err(|e| e.to_string()))
+                                .unwrap_or_else(|e| Err(e.to_string()));
+                            let _ = tx_c.send(crate::app::HardwareUpdate::GpuClockRanges(res));
+                        });
                     }
                 }
             });
@@ -724,7 +788,15 @@ fn draw_gpu_advanced_controls(
     ui.label(RichText::new("GPU Memory Offset (Advanced):").strong());
     if let Some((min_limit, max_limit)) = gpu_mem_offset_limits {
         let mut advanced_mem_offset = profile.gpu_settings.advanced_memory_offset.unwrap_or(0);
-        ui.add(Slider::new(&mut advanced_mem_offset, min_limit..=max_limit).suffix(" MHz"));
+        if ui.add(Slider::new(&mut advanced_mem_offset, min_limit..=max_limit).suffix(" MHz")).changed() {
+            if let Some(client) = dbus_client {
+                let client_c = client.clone();
+                let offset = advanced_mem_offset as f32;
+                tokio::spawn(async move {
+                    let _ = client_c.set_gpu_memory_offset(nvml_index, offset).await;
+                });
+            }
+        }
         profile.gpu_settings.advanced_memory_offset = Some(advanced_mem_offset);
     } else {
         ui.label("Fetching GPU memory offset limits...");
@@ -738,7 +810,15 @@ fn draw_gpu_advanced_controls(
             ui.label(RichText::new("GPU Power Limit (Advanced):").strong());
             if let Some((min_w, max_w)) = gpu.power_limit_range {
                 let mut power_limit = profile.gpu_settings.power_limit.unwrap_or(max_w);
-                ui.add(Slider::new(&mut power_limit, min_w..=max_w).suffix(" W"));
+                if ui.add(Slider::new(&mut power_limit, min_w..=max_w).suffix(" W")).changed() {
+                    if let Some(client) = dbus_client {
+                        let client_c = client.clone();
+                        let limit = power_limit;
+                        tokio::spawn(async move {
+                            let _ = client_c.set_gpu_power_limit(nvml_index, limit).await;
+                        });
+                    }
+                }
                 profile.gpu_settings.power_limit = Some(power_limit);
             } else {
                 ui.label("Could not determine power limit range.");

--- a/gui/src/pages/tuning.rs
+++ b/gui/src/pages/tuning.rs
@@ -483,18 +483,6 @@ fn draw_gpu_tuning(
                 });
             }
         }
-        if state.gpu_mem_clock_ranges.is_none() {
-            if let Some(client) = dbus_client {
-                let client = client.clone();
-                let tx = hw_update_tx.clone();
-                tokio::spawn(async move {
-                    let res = client.get_gpu_mem_clock_ranges(nvml_index).await
-                        .map(|r| r.map_err(|e| e.to_string()))
-                        .unwrap_or_else(|e| Err(e.to_string()));
-                    let _ = tx.send(crate::app::HardwareUpdate::GpuMemClockRanges(res));
-                });
-            }
-        }
         if state.gpu_core_offset_limits.is_none() {
             if let Some(client) = dbus_client {
                 let client = client.clone();
@@ -576,16 +564,59 @@ fn draw_gpu_standard_controls(
     ui: &mut Ui,
     profile: &mut Profile,
     gpu_clock_ranges: Option<(u32, u32)>,
-    gpu_mem_clock_ranges: Option<(u32, u32)>,
+    _gpu_mem_clock_ranges: Option<(u32, u32)>,
     gpu_core_offset_limits: Option<(i32, i32)>,
     gpu_mem_offset_limits: Option<(i32, i32)>,
     gpu_info: &lapsphere_common::types::GpuInfo,
 ) {
     let architecture = &gpu_info.architecture;
     ui.add_space(6.0);
-    // GPU Locked Clocks section
-    ui.label(RichText::new("GPU Locked Clocks:").strong());
-    if let Some((min_range, max_range)) = gpu_clock_ranges {
+
+    let mut current_core_offset = profile.gpu_settings.core_offset.unwrap_or(0.0);
+
+    // 1. GPU Core Offset
+    if !profile.gpu_settings.advanced_control && gpu_info.supports_gpu_offset {
+        ui.label(RichText::new("GPU Core Offset:").strong());
+        if let Some((min_limit, max_limit)) = gpu_core_offset_limits {
+            let step = if let Some(arch) = architecture {
+                let arch_l = arch.to_lowercase();
+                if arch_l.contains("ada") || arch_l.contains("blackwell") {
+                    7.5
+                } else {
+                    15.0
+                }
+            } else {
+                15.0
+            };
+
+            let steps_below = (min_limit.abs() as f32 / step).floor();
+            let snapped_min = -steps_below * step;
+            let steps_above = (max_limit as f32 / step).floor();
+            let snapped_max = steps_above * step;
+
+            let prev_offset = current_core_offset;
+            if ui.add(Slider::new(&mut current_core_offset, snapped_min..=snapped_max).suffix(" MHz").step_by(step as f64)).changed() {
+                let delta = current_core_offset - prev_offset;
+                // Shift locked clocks in real-time
+                if let Some(min) = profile.gpu_settings.min_gpu_clock {
+                    profile.gpu_settings.min_gpu_clock = Some((min as f32 + delta).round() as u32);
+                }
+                if let Some(max) = profile.gpu_settings.max_gpu_clock {
+                    profile.gpu_settings.max_gpu_clock = Some((max as f32 + delta).round() as u32);
+                }
+            }
+            profile.gpu_settings.core_offset = Some(current_core_offset);
+        }
+        ui.add_space(16.0);
+    }
+
+    // 2. GPU Locked Clocks (shifted by offset)
+    ui.label(RichText::new("GPU Locked Clocks (P-State 0):").strong());
+    if let Some((base_min, base_max)) = gpu_clock_ranges {
+        // Adjust bounds by current offset
+        let min_range = (base_min as f32 + current_core_offset).round() as u32;
+        let max_range = (base_max as f32 + current_core_offset).round() as u32;
+
         let mut min_gpu_clock = profile.gpu_settings.min_gpu_clock.unwrap_or(min_range);
         let mut max_gpu_clock = profile.gpu_settings.max_gpu_clock.unwrap_or(max_range);
 
@@ -615,69 +646,7 @@ fn draw_gpu_standard_controls(
 
     ui.add_space(16.0);
 
-    // Memory Locked Clocks section
-    ui.label(RichText::new("Memory Locked Clocks:").strong());
-    if let Some((min_range, max_range)) = gpu_mem_clock_ranges {
-        let mut min_mem_clock = profile.gpu_settings.min_mem_clock.unwrap_or(min_range);
-        let mut max_mem_clock = profile.gpu_settings.max_mem_clock.unwrap_or(max_range);
-
-        ui.horizontal(|ui| {
-            ui.label("Min:");
-            if ui.add(Slider::new(&mut min_mem_clock, min_range..=max_range).suffix(" MHz")).changed() {
-                if min_mem_clock > max_mem_clock {
-                    max_mem_clock = min_mem_clock;
-                }
-            }
-        });
-
-        ui.horizontal(|ui| {
-            ui.label("Max:");
-            if ui.add(Slider::new(&mut max_mem_clock, min_range..=max_range).suffix(" MHz")).changed() {
-                if max_mem_clock < min_mem_clock {
-                    min_mem_clock = max_mem_clock;
-                }
-            }
-        });
-
-        profile.gpu_settings.min_mem_clock = Some(min_mem_clock);
-        profile.gpu_settings.max_mem_clock = Some(max_mem_clock);
-    } else {
-        ui.label("Fetching memory clock ranges...");
-    }
-
-    ui.add_space(16.0);
-
-    // GPU Core Offset - only for Standard control
-    if !profile.gpu_settings.advanced_control && gpu_info.supports_gpu_offset {
-        ui.label(RichText::new("GPU Core Offset:").strong());
-        if let Some((min_limit, max_limit)) = gpu_core_offset_limits {
-            let mut core_offset = profile.gpu_settings.core_offset.unwrap_or(0.0);
-
-            let step = if let Some(arch) = architecture {
-                let arch_l = arch.to_lowercase();
-                if arch_l.contains("ada") || arch_l.contains("blackwell") {
-                    7.5
-                } else {
-                    15.0
-                }
-            } else {
-                15.0
-            };
-
-            // Snap range to multiples of step relative to 0 to ensure 0 MHz is a valid step
-            let steps_below = (min_limit.abs() as f32 / step).floor();
-            let snapped_min = -steps_below * step;
-            let steps_above = (max_limit as f32 / step).floor();
-            let snapped_max = steps_above * step;
-
-            ui.add(Slider::new(&mut core_offset, snapped_min..=snapped_max).suffix(" MHz").step_by(step as f64));
-            profile.gpu_settings.core_offset = Some(core_offset);
-        }
-
-        ui.add_space(16.0);
-    }
-
-    // GPU Memory Offset (Standard mode only)
+    // 3. GPU Memory Offset
     if !profile.gpu_settings.advanced_control && gpu_info.supports_mem_offset {
         ui.label(RichText::new("GPU Memory Offset:").strong());
         if let Some((min_limit, max_limit)) = gpu_mem_offset_limits {
@@ -711,7 +680,7 @@ fn draw_gpu_advanced_controls(
     profile: &mut Profile,
     gpu_overclock_poll_rate: &mut u64,
     gpu_clock_ranges: Option<(u32, u32)>,
-    gpu_mem_clock_ranges: Option<(u32, u32)>,
+    _gpu_mem_clock_ranges: Option<(u32, u32)>,
     gpu_mem_offset_limits: Option<(i32, i32)>,
 ) {
     ui.add_space(6.0);
@@ -739,33 +708,6 @@ fn draw_gpu_advanced_controls(
             profile.gpu_settings.advanced_max_gpu_clock = Some(max_gpu_clock);
         } else {
             ui.label("Fetching GPU clock ranges...");
-    }
-
-    ui.add_space(8.0);
-    ui.label(RichText::new("Memory Locked Clocks (Advanced):").strong());
-        if let Some((min_range, max_range)) = gpu_mem_clock_ranges {
-            let mut min_mem_clock = profile.gpu_settings.advanced_min_mem_clock.unwrap_or(min_range);
-            let mut max_mem_clock = profile.gpu_settings.advanced_max_mem_clock.unwrap_or(max_range);
-            ui.horizontal(|ui| {
-                ui.label("Min:");
-                if ui.add(Slider::new(&mut min_mem_clock, min_range..=max_range).suffix(" MHz")).changed() {
-                    if min_mem_clock > max_mem_clock {
-                        max_mem_clock = min_mem_clock;
-                    }
-                }
-            });
-            ui.horizontal(|ui| {
-                ui.label("Max:");
-                if ui.add(Slider::new(&mut max_mem_clock, min_range..=max_range).suffix(" MHz")).changed() {
-                    if max_mem_clock < min_mem_clock {
-                        min_mem_clock = max_mem_clock;
-                    }
-                }
-            });
-            profile.gpu_settings.advanced_min_mem_clock = Some(min_mem_clock);
-            profile.gpu_settings.advanced_max_mem_clock = Some(max_mem_clock);
-        } else {
-            ui.label("Fetching memory clock ranges...");
     }
 
     ui.add_space(8.0);
@@ -966,17 +908,6 @@ fn apply_gpu_settings_on_save(client: &DbusClient, gpu_settings: &lapsphere_comm
             let _ = client.set_gpu_locked_clocks(nvidia_gpu_idx, min_clock, max_clock);
         }
         
-        // Apply memory locked clocks if set
-        if gpu_settings.advanced_control {
-            if let (Some(min_mem), Some(max_mem)) =
-                (gpu_settings.advanced_min_mem_clock, gpu_settings.advanced_max_mem_clock)
-            {
-                let _ = client.set_memory_locked_clocks(nvidia_gpu_idx, min_mem, max_mem);
-            }
-        } else if let (Some(min_mem), Some(max_mem)) = (gpu_settings.min_mem_clock, gpu_settings.max_mem_clock) {
-            let _ = client.set_memory_locked_clocks(nvidia_gpu_idx, min_mem, max_mem);
-        }
-        
         // Apply core offset if set and not in advanced mode (advanced mode is handled by daemon loop)
         if !gpu_settings.advanced_control {
             if let Some(core_offset) = gpu_settings.core_offset {
@@ -1000,7 +931,6 @@ fn apply_gpu_settings_on_save(client: &DbusClient, gpu_settings: &lapsphere_comm
     } else {
         // Reset to factory settings when manual control is disabled
         let _ = client.reset_gpu_clocks(nvidia_gpu_idx);
-        let _ = client.reset_memory_locked_clocks(nvidia_gpu_idx);
         // Reset offsets to 0
         let _ = client.set_gpu_core_offset(nvidia_gpu_idx, 0.0);
         let _ = client.set_gpu_memory_offset(nvidia_gpu_idx, 0.0);

--- a/gui/src/pages/tuning.rs
+++ b/gui/src/pages/tuning.rs
@@ -526,6 +526,9 @@ fn draw_gpu_tuning(
                     state.gpu_core_offset_limits,
                     state.gpu_mem_offset_limits,
                     gpu,
+                    dbus_client,
+                    hw_update_tx.clone(),
+                    nvml_index,
                 );
             }
         }
@@ -568,6 +571,9 @@ fn draw_gpu_standard_controls(
     gpu_core_offset_limits: Option<(i32, i32)>,
     gpu_mem_offset_limits: Option<(i32, i32)>,
     gpu_info: &lapsphere_common::types::GpuInfo,
+    dbus_client: Option<&DbusClient>,
+    hw_update_tx: tokio::sync::mpsc::UnboundedSender<crate::app::HardwareUpdate>,
+    nvml_index: u32,
 ) {
     let architecture = &gpu_info.architecture;
     ui.add_space(6.0);
@@ -594,15 +600,22 @@ fn draw_gpu_standard_controls(
             let steps_above = (max_limit as f32 / step).floor();
             let snapped_max = steps_above * step;
 
-            let prev_offset = current_core_offset;
             if ui.add(Slider::new(&mut current_core_offset, snapped_min..=snapped_max).suffix(" MHz").step_by(step as f64)).changed() {
-                let delta = current_core_offset - prev_offset;
-                // Shift locked clocks in real-time
-                if let Some(min) = profile.gpu_settings.min_gpu_clock {
-                    profile.gpu_settings.min_gpu_clock = Some((min as f32 + delta).round() as u32);
-                }
-                if let Some(max) = profile.gpu_settings.max_gpu_clock {
-                    profile.gpu_settings.max_gpu_clock = Some((max as f32 + delta).round() as u32);
+                profile.gpu_settings.core_offset = Some(current_core_offset);
+
+                // Apply offset in realtime and re-query ranges
+                if let Some(client) = dbus_client {
+                    let client_c = client.clone();
+                    let tx_c = hw_update_tx.clone();
+                    let offset = current_core_offset;
+                    tokio::spawn(async move {
+                        let _ = client_c.set_gpu_core_offset(nvml_index, offset).await;
+                        // Re-query ranges immediately
+                        let res = client_c.get_gpu_clock_ranges(nvml_index).await
+                            .map(|r| r.map_err(|e| e.to_string()))
+                            .unwrap_or_else(|e| Err(e.to_string()));
+                        let _ = tx_c.send(crate::app::HardwareUpdate::GpuClockRanges(res));
+                    });
                 }
             }
             profile.gpu_settings.core_offset = Some(current_core_offset);
@@ -612,11 +625,7 @@ fn draw_gpu_standard_controls(
 
     // 2. GPU Locked Clocks (shifted by offset)
     ui.label(RichText::new("GPU Locked Clocks (P-State 0):").strong());
-    if let Some((base_min, base_max)) = gpu_clock_ranges {
-        // Adjust bounds by current offset
-        let min_range = (base_min as f32 + current_core_offset).round() as u32;
-        let max_range = (base_max as f32 + current_core_offset).round() as u32;
-
+    if let Some((min_range, max_range)) = gpu_clock_ranges {
         let mut min_gpu_clock = profile.gpu_settings.min_gpu_clock.unwrap_or(min_range);
         let mut max_gpu_clock = profile.gpu_settings.max_gpu_clock.unwrap_or(max_range);
 

--- a/gui/src/pages/tuning.rs
+++ b/gui/src/pages/tuning.rs
@@ -533,18 +533,18 @@ fn draw_gpu_tuning(
             }
         }
         if tuning_mode_advanced {
-            ui.add_space(16.0);
-            ui.separator();
             ui.add_space(12.0);
 
             let mut gpu_oc_poll = state.config.statistics_sections.gpu_overclock_poll_rate;
+            let nvidia_gpu_ref = nvidia_gpu.cloned();
             draw_gpu_advanced_controls(
                 ui,
                 profile,
                 &mut gpu_oc_poll,
                 state.gpu_clock_ranges,
-                state.gpu_mem_clock_ranges,
+                None,
                 state.gpu_mem_offset_limits,
+                nvidia_gpu_ref.as_ref(),
             );
             if gpu_oc_poll != state.config.statistics_sections.gpu_overclock_poll_rate {
                 state.config.statistics_sections.gpu_overclock_poll_rate = gpu_oc_poll;
@@ -691,6 +691,7 @@ fn draw_gpu_advanced_controls(
     gpu_clock_ranges: Option<(u32, u32)>,
     _gpu_mem_clock_ranges: Option<(u32, u32)>,
     gpu_mem_offset_limits: Option<(i32, i32)>,
+    gpu_info: Option<&lapsphere_common::types::GpuInfo>,
 ) {
     ui.add_space(6.0);
     ui.label(RichText::new("GPU Locked Clocks (Advanced):").strong());
@@ -727,6 +728,23 @@ fn draw_gpu_advanced_controls(
         profile.gpu_settings.advanced_memory_offset = Some(advanced_mem_offset);
     } else {
         ui.label("Fetching GPU memory offset limits...");
+    }
+
+    ui.add_space(16.0);
+
+    // GPU Power Limit (Advanced)
+    if let Some(gpu) = gpu_info {
+        if gpu.supports_power_limit {
+            ui.label(RichText::new("GPU Power Limit (Advanced):").strong());
+            if let Some((min_w, max_w)) = gpu.power_limit_range {
+                let mut power_limit = profile.gpu_settings.power_limit.unwrap_or(max_w);
+                ui.add(Slider::new(&mut power_limit, min_w..=max_w).suffix(" W"));
+                profile.gpu_settings.power_limit = Some(power_limit);
+            } else {
+                ui.label("Could not determine power limit range.");
+            }
+            ui.add_space(16.0);
+        }
     }
 
     ui.label(RichText::new("Advanced GPU Tuning (Dynamic Offsets):").strong());

--- a/gui/src/system_tray.rs
+++ b/gui/src/system_tray.rs
@@ -158,6 +158,21 @@ impl SystemTray {
         None
     }
 
+    pub fn set_current_profile(&self, profile_name: &str) {
+        self._tray_handle.update(|state| {
+            if let Some(index) = state.profiles.iter().position(|p| p == profile_name) {
+                state.current_profile = index;
+            }
+        });
+    }
+
+    pub fn set_profiles(&self, profiles: &[Profile]) {
+        let profile_names: Vec<String> = profiles.iter().map(|p| p.name.clone()).collect();
+        self._tray_handle.update(|state| {
+            state.profiles = profile_names;
+        });
+    }
+
 }
 
 pub enum TrayEvent {


### PR DESCRIPTION
Reworked the GPU overclocking implementation to provide real-time feedback for P-State 0 core clocks while removing redundant memory locked clock controls.

Key changes:
1. **Daemon**: `get_gpu_clock_ranges` now specifically queries `PerformanceState::Zero` to ensure overclocking bounds are relevant to high-performance states.
2. **GUI**:
    - Reordered sliders in Tuning page: Core Offset now appears above Locked Clocks.
    - Added real-time calculation logic: adjusting the Core Offset immediately shifts the effective value and slider bounds of the Locked Clocks display.
    - Removed all "Memory Locked Clocks" sections and logic based on findings that memory frequency is fixed per performance state.
3. **Cleanup**: Removed unused D-Bus methods (`SetMemoryLockedClocks`, `ResetMemoryLockedClocks`, `GetGpuMemClockRanges`) and their implementations in the daemon and GUI client.
4. **Consistency**: Ensured both Standard and Advanced tuning modes reflect these improvements.

---
*PR created automatically by Jules for task [7528493382255844827](https://jules.google.com/task/7528493382255844827) started by @weter11*