### PR TITLE
Implement Gamepad Monitoring and Persistence

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -198,6 +198,37 @@ pub struct StorageDevice {
     pub write_iops: Option<f64>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GamepadInfo {
+    pub name: String,
+    pub id: String, // Unique identifier (e.g. sysfs path or serial)
+    pub status: GamepadStatus,
+    pub battery_level: Option<u8>,
+    pub connection_type: ConnectionType,
+    pub power_status: PowerStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum GamepadStatus {
+    Connected,
+    Disconnected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ConnectionType {
+    Wired,
+    Wireless,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum PowerStatus {
+    Charging,
+    Discharging,
+    Full,
+    Unknown,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MountInfo {
     pub mount_point: String,
@@ -395,6 +426,8 @@ pub struct AppConfig {
     pub profiles: Vec<Profile>,
     pub current_profile: String,
     pub battery_settings: BatterySettings,
+    #[serde(default)]
+    pub remembered_gamepads: Vec<GamepadInfo>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -422,6 +455,8 @@ pub struct StatisticsSections {
     pub show_wifi: bool,
     pub show_storage: bool,
     pub show_fans: bool,
+    #[serde(default = "default_show_gamepads")]
+    pub show_gamepads: bool,
     pub section_order: Vec<String>,
     // Polling rates in milliseconds
     pub cpu_poll_rate: u64,
@@ -432,6 +467,8 @@ pub struct StatisticsSections {
     pub wifi_poll_rate: u64,
     pub storage_poll_rate: u64,
     pub fans_poll_rate: u64,
+    #[serde(default = "default_gamepad_poll_rate")]
+    pub gamepad_poll_rate: u64,
     #[serde(default = "default_gpu_overclock_poll_rate")]
     pub gpu_overclock_poll_rate: u64,
 }
@@ -444,7 +481,15 @@ fn default_memory_poll_rate() -> u64 {
     1000
 }
 
+fn default_gamepad_poll_rate() -> u64 {
+    5000
+}
+
 fn default_show_memory() -> bool {
+    true
+}
+
+fn default_show_gamepads() -> bool {
     true
 }
 
@@ -468,6 +513,7 @@ impl Default for AppConfig {
             profiles: vec![Profile::default()],
             current_profile: "Standard".to_string(),
             battery_settings: BatterySettings::default(),
+            remembered_gamepads: vec![],
         }
     }
 }
@@ -493,6 +539,7 @@ impl Default for StatisticsSections {
             show_wifi: true,
             show_storage: true,
             show_fans: true,
+            show_gamepads: true,
             section_order: vec![
                 "SystemInfo".to_string(),
                 "CPU".to_string(),
@@ -502,6 +549,7 @@ impl Default for StatisticsSections {
                 "WiFi".to_string(),
                 "Storage".to_string(),
                 "Fans".to_string(),
+                "Gamepads".to_string(),
             ],
             cpu_poll_rate: 1000,            // 1 second
             memory_poll_rate: default_memory_poll_rate(),
@@ -510,6 +558,7 @@ impl Default for StatisticsSections {
             wifi_poll_rate: 5000,           // 5 seconds
             storage_poll_rate: 5 * 1000,    // 5 seconds
             fans_poll_rate: 1000,           // 1 second
+            gamepad_poll_rate: 5000,        // 5 seconds
             gpu_overclock_poll_rate: 1000,
         }
     }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -198,35 +198,45 @@ pub struct StorageDevice {
     pub write_iops: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct GamepadInfo {
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub id: String, // Dynamic identifier (e.g. input0)
+    #[serde(default)]
     pub uid: String, // Stable unique identifier (e.g. ID_PATH from udev)
+    #[serde(default)]
     pub status: GamepadStatus,
+    #[serde(default)]
     pub battery_level: Option<u8>,
+    #[serde(default)]
     pub connection_type: ConnectionType,
+    #[serde(default)]
     pub power_status: PowerStatus,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub enum GamepadStatus {
     Connected,
+    #[default]
     Disconnected,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub enum ConnectionType {
     Wired,
     Wireless,
+    #[default]
     Unknown,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub enum PowerStatus {
     Charging,
     Discharging,
     Full,
+    #[default]
     Unknown,
 }
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -201,7 +201,8 @@ pub struct StorageDevice {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GamepadInfo {
     pub name: String,
-    pub id: String, // Unique identifier (e.g. sysfs path or serial)
+    pub id: String, // Dynamic identifier (e.g. input0)
+    pub uid: String, // Stable unique identifier (e.g. ID_PATH from udev)
     pub status: GamepadStatus,
     pub battery_level: Option<u8>,
     pub connection_type: ConnectionType,

--- a/daemon/src/dbus_interface.rs
+++ b/daemon/src/dbus_interface.rs
@@ -107,6 +107,14 @@ impl ControlInterface {
         )
     }
 
+    async fn get_gamepad_info(&self) -> Result<String, zbus::fdo::Error> {
+        log_api_json!(
+            "GetGamepadInfo",
+            crate::hardware_detection::get_gamepad_info(),
+            |i: &Vec<GamepadInfo>| format!("count={}", i.len())
+        )
+    }
+
     async fn set_cpu_governor(&self, governor: &str) -> Result<(), zbus::fdo::Error> {
         log_api!(
             "SetCpuGovernor",

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -3018,6 +3018,19 @@ pub fn get_gamepad_info() -> Result<Vec<GamepadInfo>> {
                     }
                 }
 
+                // Apply exclusions based on name (even if udev says joystick)
+                if is_gamepad {
+                    if let Ok(device_name) = fs::read_to_string(path.join("name")) {
+                        let device_name_lower = device_name.to_lowercase();
+                        if device_name_lower.contains("touchpad") ||
+                           device_name_lower.contains("motion sensors") ||
+                           device_name_lower.contains("consumer control") ||
+                           device_name_lower.contains("system control") {
+                            is_gamepad = false;
+                        }
+                    }
+                }
+
                 if is_gamepad {
                     if let Ok(device_name) = fs::read_to_string(path.join("name")) {
                         let device_name = device_name.trim().to_string();

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -2948,6 +2948,121 @@ fn read_wifi_rates(interface: &str, tx_bytes: u64, rx_bytes: u64) -> (Option<f64
     rates
 }
 
+pub fn get_gamepad_info() -> Result<Vec<GamepadInfo>> {
+    let mut gamepads = Vec::new();
+    let mut seen_names = std::collections::HashSet::new();
+
+    if let Ok(entries) = fs::read_dir("/sys/class/input") {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with("input") {
+                let path = entry.path();
+                if let Ok(device_name) = fs::read_to_string(path.join("name")) {
+                    let device_name = device_name.trim().to_string();
+
+                    // Basic heuristic for gamepads
+                    let is_gamepad = device_name.to_lowercase().contains("controller")
+                        || device_name.to_lowercase().contains("gamepad")
+                        || device_name.to_lowercase().contains("joystick")
+                        || path.join("capabilities/abs").exists();
+
+                    if is_gamepad
+                        && !device_name.to_lowercase().contains("keyboard")
+                        && !seen_names.contains(&device_name)
+                    {
+                        let bustype = fs::read_to_string(path.join("id/bustype"))
+                            .ok()
+                            .and_then(|s| u16::from_str_radix(s.trim(), 16).ok())
+                            .unwrap_or(0);
+
+                        let connection_type = match bustype {
+                            0x03 => ConnectionType::Wired,
+                            0x05 => ConnectionType::Wireless,
+                            _ => ConnectionType::Unknown,
+                        };
+
+                        let (battery_level, power_status) = find_battery_for_input(&path);
+
+                        gamepads.push(GamepadInfo {
+                            name: device_name.clone(),
+                            id: name,
+                            status: GamepadStatus::Connected,
+                            battery_level,
+                            connection_type,
+                            power_status,
+                        });
+                        seen_names.insert(device_name);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(gamepads)
+}
+
+fn find_battery_for_input(input_path: &Path) -> (Option<u8>, PowerStatus) {
+    if let Ok(device_path) = fs::canonicalize(input_path.join("device")) {
+        let mut current = Some(device_path.as_path());
+        while let Some(path) = current {
+            let ps_path = path.join("power_supply");
+            if ps_path.exists() {
+                if let Ok(ps_entries) = fs::read_dir(ps_path) {
+                    for ps_entry in ps_entries.flatten() {
+                        let mut level = None;
+                        let mut status = PowerStatus::Unknown;
+                        if let Ok(cap) = fs::read_to_string(ps_entry.path().join("capacity")) {
+                            level = cap.trim().parse().ok();
+                        }
+                        if let Ok(st) = fs::read_to_string(ps_entry.path().join("status")) {
+                            status = match st.trim().to_lowercase().as_str() {
+                                "charging" => PowerStatus::Charging,
+                                "discharging" => PowerStatus::Discharging,
+                                "full" => PowerStatus::Full,
+                                _ => PowerStatus::Unknown,
+                            };
+                        }
+                        return (level, status);
+                    }
+                }
+            }
+
+            // Also check for power_supply as a sibling in some cases or child of parent
+            current = path.parent();
+            if let Some(p) = current {
+                if p == Path::new("/sys/devices") || p == Path::new("/sys") {
+                    break;
+                }
+            }
+        }
+    }
+
+    // Fallback: search all power supplies for names matching the input device
+    if let Ok(ps_entries) = fs::read_dir("/sys/class/power_supply") {
+        for ps_entry in ps_entries.flatten() {
+            let ps_name = ps_entry.file_name().to_string_lossy().to_lowercase();
+            if ps_name.contains("controller") || ps_name.contains("gamepad") {
+                 let mut level = None;
+                 let mut status = PowerStatus::Unknown;
+                 if let Ok(cap) = fs::read_to_string(ps_entry.path().join("capacity")) {
+                     level = cap.trim().parse().ok();
+                 }
+                 if let Ok(st) = fs::read_to_string(ps_entry.path().join("status")) {
+                     status = match st.trim().to_lowercase().as_str() {
+                         "charging" => PowerStatus::Charging,
+                         "discharging" => PowerStatus::Discharging,
+                         "full" => PowerStatus::Full,
+                         _ => PowerStatus::Unknown,
+                     };
+                 }
+                 return (level, status);
+            }
+        }
+    }
+
+    (None, PowerStatus::Unknown)
+}
+
 pub fn get_battery_info() -> Result<BatteryInfo> {
     let base = if Path::new("/sys/class/power_supply/BAT0").exists() {
         "/sys/class/power_supply/BAT0"

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -2950,48 +2950,105 @@ fn read_wifi_rates(interface: &str, tx_bytes: u64, rx_bytes: u64) -> (Option<f64
 
 pub fn get_gamepad_info() -> Result<Vec<GamepadInfo>> {
     let mut gamepads = Vec::new();
-    let mut seen_names = std::collections::HashSet::new();
+    let mut seen_uids = std::collections::HashSet::new();
 
     if let Ok(entries) = fs::read_dir("/sys/class/input") {
         for entry in entries.flatten() {
-            let name = entry.file_name().to_string_lossy().to_string();
-            if name.starts_with("input") {
+            let input_name = entry.file_name().to_string_lossy().to_string();
+            if input_name.starts_with("input") {
                 let path = entry.path();
-                if let Ok(device_name) = fs::read_to_string(path.join("name")) {
-                    let device_name = device_name.trim().to_string();
 
-                    // Basic heuristic for gamepads
-                    let is_gamepad = device_name.to_lowercase().contains("controller")
-                        || device_name.to_lowercase().contains("gamepad")
-                        || device_name.to_lowercase().contains("joystick")
-                        || path.join("capabilities/abs").exists();
+                // Find event child to check udev properties
+                let mut is_gamepad = false;
+                let mut udev_uid = None;
+                if let Ok(children) = fs::read_dir(&path) {
+                    for child in children.flatten() {
+                        let child_name = child.file_name().to_string_lossy().to_string();
+                        if child_name.starts_with("event") {
+                            if let Ok(uevent) = fs::read_to_string(child.path().join("uevent")) {
+                                let mut major = None;
+                                let mut minor = None;
+                                for line in uevent.lines() {
+                                    if let Some(val) = line.strip_prefix("MAJOR=") {
+                                        major = Some(val);
+                                    } else if let Some(val) = line.strip_prefix("MINOR=") {
+                                        minor = Some(val);
+                                    }
+                                }
 
-                    if is_gamepad
-                        && !device_name.to_lowercase().contains("keyboard")
-                        && !seen_names.contains(&device_name)
-                    {
-                        let bustype = fs::read_to_string(path.join("id/bustype"))
-                            .ok()
-                            .and_then(|s| u16::from_str_radix(s.trim(), 16).ok())
-                            .unwrap_or(0);
+                                if let (Some(maj), Some(min)) = (major, minor) {
+                                    let udev_path = format!("/run/udev/data/c{}:{}", maj, min);
+                                    if let Ok(udev_data) = fs::read_to_string(udev_path) {
+                                        if udev_data.contains("E:ID_INPUT_JOYSTICK=1") {
+                                            is_gamepad = true;
+                                        }
 
-                        let connection_type = match bustype {
-                            0x03 => ConnectionType::Wired,
-                            0x05 => ConnectionType::Wireless,
-                            _ => ConnectionType::Unknown,
-                        };
+                                        // Try to find a stable UID from udev data
+                                        let mut id_path = None;
+                                        let mut id_serial = None;
+                                        for line in udev_data.lines() {
+                                            if let Some(val) = line.strip_prefix("E:ID_PATH=") {
+                                                id_path = Some(val.to_string());
+                                            } else if let Some(val) = line.strip_prefix("E:ID_SERIAL=") {
+                                                id_serial = Some(val.to_string());
+                                            }
+                                        }
+                                        udev_uid = id_path.or(id_serial);
 
-                        let (battery_level, power_status) = find_battery_for_input(&path);
+                                        if is_gamepad {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
-                        gamepads.push(GamepadInfo {
-                            name: device_name.clone(),
-                            id: name,
-                            status: GamepadStatus::Connected,
-                            battery_level,
-                            connection_type,
-                            power_status,
-                        });
-                        seen_names.insert(device_name);
+                // Fallback to name heuristic if udev info is missing or not joystick
+                if !is_gamepad {
+                    if let Ok(device_name) = fs::read_to_string(path.join("name")) {
+                        let device_name_lower = device_name.to_lowercase();
+                        if (device_name_lower.contains("controller") ||
+                            device_name_lower.contains("gamepad") ||
+                            device_name_lower.contains("joystick")) &&
+                           !device_name_lower.contains("keyboard") {
+                            is_gamepad = true;
+                        }
+                    }
+                }
+
+                if is_gamepad {
+                    if let Ok(device_name) = fs::read_to_string(path.join("name")) {
+                        let device_name = device_name.trim().to_string();
+                        // Use sysfs path as absolute fallback for UID if udev failed
+                        let uid = udev_uid.unwrap_or_else(|| path.to_string_lossy().to_string());
+
+                        if !seen_uids.contains(&uid) {
+                            let bustype = fs::read_to_string(path.join("id/bustype"))
+                                .ok()
+                                .and_then(|s| u16::from_str_radix(s.trim(), 16).ok())
+                                .unwrap_or(0);
+
+                            let connection_type = match bustype {
+                                0x03 => ConnectionType::Wired,
+                                0x05 => ConnectionType::Wireless,
+                                _ => ConnectionType::Unknown,
+                            };
+
+                            let (battery_level, power_status) = find_battery_for_input(&path);
+
+                            gamepads.push(GamepadInfo {
+                                name: device_name,
+                                id: input_name,
+                                uid: uid.clone(),
+                                status: GamepadStatus::Connected,
+                                battery_level,
+                                connection_type,
+                                power_status,
+                            });
+                            seen_uids.insert(uid);
+                        }
                     }
                 }
             }

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -506,13 +506,15 @@ impl LapSphereApp {
 
                     // Update existing ones and mark as connected/disconnected
                     for remembered in &mut self.state.config.remembered_gamepads {
-                        if let Some(connected) = connected_gamepads.iter().find(|c| c.name == remembered.name) {
+                        if let Some(connected) = connected_gamepads.iter().find(|c| c.uid == remembered.uid) {
                             if remembered.status != GamepadStatus::Connected ||
                                remembered.battery_level != connected.battery_level ||
                                remembered.power_status != connected.power_status ||
-                               remembered.connection_type != connected.connection_type
+                               remembered.connection_type != connected.connection_type ||
+                               remembered.name != connected.name
                             {
                                 remembered.status = GamepadStatus::Connected;
+                                remembered.name = connected.name.clone();
                                 remembered.battery_level = connected.battery_level;
                                 remembered.power_status = connected.power_status.clone();
                                 remembered.connection_type = connected.connection_type.clone();
@@ -526,7 +528,7 @@ impl LapSphereApp {
 
                     // Add new ones
                     for connected in connected_gamepads {
-                        if !self.state.config.remembered_gamepads.iter().any(|r| r.name == connected.name) {
+                        if !self.state.config.remembered_gamepads.iter().any(|r| r.uid == connected.uid) {
                             self.state.config.remembered_gamepads.push(connected);
                             changed = true;
                         }

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -42,6 +42,7 @@ pub struct AppState {
     pub gpu_info: Vec<GpuInfo>,
     pub battery_info: Option<BatteryInfo>,
     pub wifi_info: Vec<WiFiInfo>,
+    pub gamepad_info: Vec<GamepadInfo>,
     pub fan_info: Vec<FanInfo>,
     pub storage_device_info: Vec<StorageDevice>,
     pub mount_info: Vec<MountInfo>,
@@ -102,6 +103,7 @@ impl AppState {
             gpu_info: Vec::new(),
             battery_info: None,
             wifi_info: Vec::new(),
+            gamepad_info: Vec::new(),
             fan_info: Vec::new(),
             storage_device_info: Vec::new(),
             mount_info: Vec::new(),
@@ -210,6 +212,7 @@ pub enum HardwareUpdate {
     GpuInfo(Vec<GpuInfo>),
     BatteryInfo(BatteryInfo),
     WifiInfo(Vec<WiFiInfo>),
+    GamepadInfo(Vec<GamepadInfo>),
     FanInfo(Vec<FanInfo>),
     StorageDeviceInfo(Vec<StorageDevice>),
     MountInfo(Vec<MountInfo>),
@@ -307,6 +310,13 @@ impl LapSphereApp {
                                     Err(e) => log::error!("DBus error getting WiFi info: {}", e),
                                 }
                             }
+                            "gamepads" => {
+                                match client.get_gamepad_info().await {
+                                    Ok(Ok(info)) => { let _ = tx.send(HardwareUpdate::GamepadInfo(info)); }
+                                    Ok(Err(e)) => log::error!("Failed to get Gamepad info: {}", e),
+                                    Err(e) => log::error!("DBus error getting Gamepad info: {}", e),
+                                }
+                            }
                             "storage" => {
                                 match client.get_storage_device_info().await {
                                     Ok(Ok(info)) => { let _ = tx.send(HardwareUpdate::StorageDeviceInfo(info)); }
@@ -346,6 +356,7 @@ impl LapSphereApp {
             let _ = handle.register("fans".to_string(), Duration::from_millis(state.config.statistics_sections.fans_poll_rate));
             let _ = handle.register("battery".to_string(), Duration::from_millis(state.config.statistics_sections.battery_poll_rate));
             let _ = handle.register("wifi".to_string(), Duration::from_millis(state.config.statistics_sections.wifi_poll_rate));
+            let _ = handle.register("gamepads".to_string(), Duration::from_millis(state.config.statistics_sections.gamepad_poll_rate));
             let _ = handle.register("storage".to_string(), Duration::from_millis(state.config.statistics_sections.storage_poll_rate));
             let _ = handle.register("mount".to_string(), Duration::from_millis(state.config.statistics_sections.storage_poll_rate));
             let _ = handle.register("gpu_overclock".to_string(), Duration::from_millis(state.config.statistics_sections.gpu_overclock_poll_rate));
@@ -487,6 +498,43 @@ impl LapSphereApp {
                 }
                 HardwareUpdate::WifiInfo(info) => {
                     self.state.wifi_info = info;
+                }
+                HardwareUpdate::GamepadInfo(connected_gamepads) => {
+                    self.state.gamepad_info = connected_gamepads.clone();
+
+                    let mut changed = false;
+
+                    // Update existing ones and mark as connected/disconnected
+                    for remembered in &mut self.state.config.remembered_gamepads {
+                        if let Some(connected) = connected_gamepads.iter().find(|c| c.name == remembered.name) {
+                            if remembered.status != GamepadStatus::Connected ||
+                               remembered.battery_level != connected.battery_level ||
+                               remembered.power_status != connected.power_status ||
+                               remembered.connection_type != connected.connection_type
+                            {
+                                remembered.status = GamepadStatus::Connected;
+                                remembered.battery_level = connected.battery_level;
+                                remembered.power_status = connected.power_status.clone();
+                                remembered.connection_type = connected.connection_type.clone();
+                                changed = true;
+                            }
+                        } else if remembered.status != GamepadStatus::Disconnected {
+                            remembered.status = GamepadStatus::Disconnected;
+                            changed = true;
+                        }
+                    }
+
+                    // Add new ones
+                    for connected in connected_gamepads {
+                        if !self.state.config.remembered_gamepads.iter().any(|r| r.name == connected.name) {
+                            self.state.config.remembered_gamepads.push(connected);
+                            changed = true;
+                        }
+                    }
+
+                    if changed {
+                        let _ = self.state.save_settings();
+                    }
                 }
                 HardwareUpdate::FanInfo(info) => {
                     self.state.fan_info = info;
@@ -790,6 +838,7 @@ struct SettingsConfig {
     statistics_sections: StatisticsSections,
     tuning_section_order: Vec<String>,
     battery_settings: BatterySettings,
+    remembered_gamepads: Vec<GamepadInfo>,
 }
 
 impl Default for SettingsConfig {
@@ -805,6 +854,7 @@ impl Default for SettingsConfig {
             statistics_sections: config.statistics_sections,
             tuning_section_order: config.tuning_section_order,
             battery_settings: config.battery_settings,
+            remembered_gamepads: config.remembered_gamepads.clone(),
         }
     }
 }
@@ -821,6 +871,7 @@ impl From<&AppConfig> for SettingsConfig {
             statistics_sections: config.statistics_sections.clone(),
             tuning_section_order: config.tuning_section_order.clone(),
             battery_settings: config.battery_settings.clone(),
+            remembered_gamepads: config.remembered_gamepads.clone(),
         }
     }
 }
@@ -836,6 +887,7 @@ impl SettingsConfig {
         config.statistics_sections = self.statistics_sections.clone();
         config.tuning_section_order = self.tuning_section_order.clone();
         config.battery_settings = self.battery_settings.clone();
+        config.remembered_gamepads = self.remembered_gamepads.clone();
     }
 }
 

--- a/gui/src/dbus_client.rs
+++ b/gui/src/dbus_client.rs
@@ -19,6 +19,7 @@ pub enum DbusCommand {
     GetStorageDeviceInfo { reply: oneshot::Sender<Result<Vec<StorageDevice>>> },
     GetMountInfo { reply: oneshot::Sender<Result<Vec<MountInfo>>> },
     GetWifiInfo { reply: oneshot::Sender<Result<Vec<WiFiInfo>>> },
+    GetGamepadInfo { reply: oneshot::Sender<Result<Vec<GamepadInfo>>> },
     GetTdpProfiles { reply: oneshot::Sender<Result<Vec<String>>> },
     GetHardwareInterfaceInfo { reply: oneshot::Sender<Result<String>> },
     GetKeyboardCapabilities { reply: oneshot::Sender<Result<KeyboardCapabilities>> },
@@ -118,6 +119,12 @@ impl DbusClient {
     pub fn get_wifi_info(&self) -> oneshot::Receiver<Result<Vec<WiFiInfo>>> {
         let (tx, rx) = oneshot::channel();
         let _ = self.command_tx.send(DbusCommand::GetWifiInfo { reply: tx });
+        rx
+    }
+
+    pub fn get_gamepad_info(&self) -> oneshot::Receiver<Result<Vec<GamepadInfo>>> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.command_tx.send(DbusCommand::GetGamepadInfo { reply: tx });
         rx
     }
 
@@ -331,6 +338,12 @@ async fn dbus_worker(mut command_rx: mpsc::UnboundedReceiver<DbusCommand>) -> Re
             let res: Result<(), anyhow::Error> = match command {
                 DbusCommand::GetSystemInfo { reply } => {
                     let result = get_system_info_impl(&connection).await;
+                    let is_err = result.is_err();
+                    let _ = reply.send(result);
+                    if is_err { Err(anyhow::anyhow!("DBus call failed")) } else { Ok(()) }
+                }
+                DbusCommand::GetGamepadInfo { reply } => {
+                    let result = get_gamepad_info_impl(&connection).await;
                     let is_err = result.is_err();
                     let _ = reply.send(result);
                     if is_err { Err(anyhow::anyhow!("DBus call failed")) } else { Ok(()) }
@@ -698,6 +711,18 @@ async fn get_wifi_info_impl(conn: &Connection) -> Result<Vec<WiFiInfo>> {
     ).await?;
 
     let json: String = proxy.call("GetWifiInfo", &()).await?;
+    Ok(serde_json::from_str(&json)?)
+}
+
+async fn get_gamepad_info_impl(conn: &Connection) -> Result<Vec<GamepadInfo>> {
+    let proxy = zbus::Proxy::new(
+        conn,
+        "io.lapsphere.Control",
+        "/io/lapsphere/Control",
+        "io.lapsphere.Control",
+    ).await?;
+
+    let json: String = proxy.call("GetGamepadInfo", &()).await?;
     Ok(serde_json::from_str(&json)?)
 }
 

--- a/gui/src/pages/settings.rs
+++ b/gui/src/pages/settings.rs
@@ -377,6 +377,19 @@ fn draw_main_settings(ui: &mut Ui, state: &mut AppState, theme: &mut LapSphereTh
     ui.add_space(12.0);
     ui.separator();
     ui.add_space(12.0);
+
+    // Gamepads database
+    ui.label(RichText::new("Gamepads").strong().heading());
+    ui.add_space(6.0);
+    if ui.button("🗑 Remove database with previously connected gamepads").clicked() {
+        state.config.remembered_gamepads.clear();
+        let _ = state.save_settings();
+        state.show_message("Gamepad database cleared", false);
+    }
+
+    ui.add_space(12.0);
+    ui.separator();
+    ui.add_space(12.0);
 }
 
 fn draw_stats_configuration(ui: &mut Ui, state: &mut AppState, dbus_client: Option<&DbusClient>) {
@@ -406,6 +419,9 @@ fn draw_stats_configuration(ui: &mut Ui, state: &mut AppState, dbus_client: Opti
         let _ = state.save_settings();
     }
     if ui.checkbox(&mut state.config.statistics_sections.show_fans, "Show fans").changed() {
+        let _ = state.save_settings();
+    }
+    if ui.checkbox(&mut state.config.statistics_sections.show_gamepads, "Show gamepads").changed() {
         let _ = state.save_settings();
     }
     
@@ -579,6 +595,22 @@ fn draw_stats_configuration(ui: &mut Ui, state: &mut AppState, dbus_client: Opti
         }
     });
 
+    let mut gamepad_poll = (state.config.statistics_sections.gamepad_poll_rate as f32) / 1000.0;
+    ui.horizontal(|ui| {
+        ui.label("Gamepads:");
+        if ui.add(Slider::new(&mut gamepad_poll, 0.5..=30.0).step_by(0.5).suffix(" s")).changed() {
+            let new_rate = (gamepad_poll * 1000.0) as u64;
+            state.config.statistics_sections.gamepad_poll_rate = new_rate;
+            let _ = state.save_settings();
+            // Update coordinator interval
+            if let Some(ref handle) = state.coordinator_handle {
+                let _ = handle.update_interval("gamepads".to_string(), std::time::Duration::from_millis(new_rate));
+            }
+            if let Some(client) = dbus_client {
+                let _ = client.update_polling_interval("gamepads", new_rate);
+            }
+        }
+    });
 }
 
 fn draw_hardware_info(ui: &mut Ui, state: &AppState) {

--- a/gui/src/pages/statistics.rs
+++ b/gui/src/pages/statistics.rs
@@ -735,19 +735,11 @@ fn draw_storage_info(ui: &mut Ui, state: &AppState) {
         });
 }
 
-fn draw_gamepad_info(ui: &mut Ui, state: &mut AppState) {
-    let mut clear_requested = false;
+fn draw_gamepad_info(ui: &mut Ui, state: &AppState) {
     CollapsingHeader::new(RichText::new("🎮 Gamepads").heading())
         .default_open(true)
         .show(ui, |ui| {
             if !state.config.remembered_gamepads.is_empty() {
-                ui.horizontal(|ui| {
-                    if ui.button("🗑 Remove Gamepads Database").on_hover_text("Remove all previously connected gamepads from history").clicked() {
-                        clear_requested = true;
-                    }
-                });
-                ui.add_space(4.0);
-
                 for (idx, gamepad) in state.config.remembered_gamepads.iter().enumerate() {
                     if idx > 0 {
                         ui.add_space(4.0);
@@ -795,12 +787,6 @@ fn draw_gamepad_info(ui: &mut Ui, state: &mut AppState) {
                 ui.label("No gamepads discovered");
             }
         });
-
-    if clear_requested {
-        state.config.remembered_gamepads.clear();
-        let _ = state.save_settings();
-        state.show_message("Gamepad database cleared", false);
-    }
 }
 
 fn draw_fan_info(ui: &mut Ui, state: &AppState) {

--- a/gui/src/pages/statistics.rs
+++ b/gui/src/pages/statistics.rs
@@ -1,9 +1,10 @@
 use egui::{Ui, ScrollArea, CollapsingHeader, Grid, ProgressBar, RichText};
 use egui::Color32;
+use lapsphere_common::types::GamepadStatus;
 use crate::app::AppState;
 use crate::theme::{temp_color, load_color, power_color};
 
-pub const STATISTICS_SECTIONS: [(&str, &str); 8] = [
+pub const STATISTICS_SECTIONS: [(&str, &str); 9] = [
     ("SystemInfo", "System Info"),
     ("CPU", "CPU"),
     ("Memory", "Memory"),
@@ -12,6 +13,7 @@ pub const STATISTICS_SECTIONS: [(&str, &str); 8] = [
     ("WiFi", "WiFi"),
     ("Storage", "Storage"),
     ("Fans", "Fans"),
+    ("Gamepads", "Gamepads"),
 ];
 
 const WIFI_NOT_CONNECTED: &str = "Not connected";
@@ -81,6 +83,10 @@ pub fn draw(ui: &mut Ui, state: &mut AppState) {
                     }
                     "Fans" if state.config.statistics_sections.show_fans => {
                         draw_fan_info(ui, state);
+                        ui.add_space(6.0);
+                    }
+                    "Gamepads" if state.config.statistics_sections.show_gamepads => {
+                        draw_gamepad_info(ui, state);
                         ui.add_space(6.0);
                     }
                     _ => {}
@@ -727,6 +733,74 @@ fn draw_storage_info(ui: &mut Ui, state: &AppState) {
                 }
             }
         });
+}
+
+fn draw_gamepad_info(ui: &mut Ui, state: &mut AppState) {
+    let mut clear_requested = false;
+    CollapsingHeader::new(RichText::new("🎮 Gamepads").heading())
+        .default_open(true)
+        .show(ui, |ui| {
+            if !state.config.remembered_gamepads.is_empty() {
+                ui.horizontal(|ui| {
+                    if ui.button("🗑 Remove Gamepads Database").on_hover_text("Remove all previously connected gamepads from history").clicked() {
+                        clear_requested = true;
+                    }
+                });
+                ui.add_space(4.0);
+
+                for (idx, gamepad) in state.config.remembered_gamepads.iter().enumerate() {
+                    if idx > 0 {
+                        ui.add_space(4.0);
+                        ui.separator();
+                        ui.add_space(4.0);
+                    }
+                    ui.label(RichText::new(&gamepad.name).strong());
+                    Grid::new(format!("gamepad_grid_{}", gamepad.name))
+                        .num_columns(2)
+                        .spacing([36.0, 6.0])
+                        .striped(true)
+                        .show(ui, |ui| {
+                            ui.label("Status:");
+                            let status_color = match gamepad.status {
+                                GamepadStatus::Connected => Color32::from_rgb(80, 200, 120),
+                                GamepadStatus::Disconnected => Color32::from_rgb(200, 80, 80),
+                            };
+                            ui.colored_label(status_color, format!("{:?}", gamepad.status));
+                            ui.end_row();
+
+                            if gamepad.status == GamepadStatus::Connected {
+                                ui.label("Connection:");
+                                ui.label(format!("{:?}", gamepad.connection_type));
+                                ui.end_row();
+
+                                ui.label("Battery:");
+                                if let Some(level) = gamepad.battery_level {
+                                    ui.horizontal(|ui| {
+                                        ui.add(ProgressBar::new(level as f32 / 100.0)
+                                            .text(format!("{}%", level))
+                                            .desired_width(120.0));
+                                    });
+                                } else {
+                                    ui.label("—");
+                                }
+                                ui.end_row();
+
+                                ui.label("Power Status:");
+                                ui.label(format!("{:?}", gamepad.power_status));
+                                ui.end_row();
+                            }
+                        });
+                }
+            } else {
+                ui.label("No gamepads discovered");
+            }
+        });
+
+    if clear_requested {
+        state.config.remembered_gamepads.clear();
+        let _ = state.save_settings();
+        state.show_message("Gamepad database cleared", false);
+    }
 }
 
 fn draw_fan_info(ui: &mut Ui, state: &AppState) {


### PR DESCRIPTION
This change implements gamepad monitoring for the LapSphere application. It includes:
1. Daemon-side detection of gamepads and their associated batteries via sysfs.
2. D-Bus interface updates to transmit gamepad data to the GUI.
3. GUI-side display of gamepad status (Connected/Disconnected), battery level, charging status, and connection type (Wired/Wireless).
4. Logic to remember previously connected gamepads across app restarts by storing them in the settings file.
5. UI elements to manage the gamepad "database" (clear history) and configure polling/visibility.

---
*PR created automatically by Jules for task [17999058554713544532](https://jules.google.com/task/17999058554713544532) started by @weter11*