### PR TITLE
Reduce logging verbosity and implement GPU metadata caching

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=lapsphere
 pkgver=0.1.0
 pkgrel=1
-pkgdesc="Hardware control application for Clevo/Uniwill laptops"
+pkgdesc="Hardware control application for Uniwill/Clevo laptops"
 arch=('x86_64')
 url="https://github.com/weter11/lapsphere"
 license=('GPL2')

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -119,6 +119,8 @@ pub struct GpuInfo {
     pub max_memory_clock: Option<u32>,
     pub core_clock_range: Option<(u32, u32)>,
     pub memory_clock_range: Option<(u32, u32)>,
+    pub core_offset_limits: Option<(i32, i32)>,
+    pub memory_offset_limits: Option<(i32, i32)>,
     pub is_desktop: bool,
     pub architecture: Option<String>,
     pub nvml_index: Option<u32>,

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,9 +1,99 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum GpuType {
-    Integrated,
-    Discrete,
+pub struct SystemInfo {
+    pub product_name: String,
+    pub product_sku: String,
+    pub manufacturer: String,
+    pub board_name: String,
+    pub bios_version: String,
+    pub kernel_modules: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LogEntry {
+    pub level: String,
+    pub target: String,
+    pub message: String,
+    pub timestamp: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CpuInfo {
+    pub name: String,
+    pub average_frequency: u64,
+    pub average_load: f32,
+    pub package_temp: f32,
+    pub package_power: Option<f32>,
+    pub power_source: Option<String>,
+    pub all_power_sources: Vec<PowerSource>,
+    pub cores: Vec<CoreInfo>,
+    pub physical_cores: u32,
+    pub logical_cores: u32,
+    pub governor: String,
+    pub available_governors: Vec<String>,
+    pub boost_enabled: bool,
+    pub smt_enabled: bool,
+    pub scaling_driver: String,
+    pub amd_pstate_status: Option<String>,
+    pub intel_pstate_status: Option<String>,
+    pub min_freq: Option<u64>,
+    pub max_freq: Option<u64>,
+    pub hw_min_freq: Option<u64>,
+    pub hw_max_freq: Option<u64>,
+    pub energy_performance_preference: Option<String>,
+    pub available_epp_options: Vec<String>,
+    pub scheduler: String,
+    pub available_schedulers: Vec<String>,
+    pub tdp0: Option<u32>,
+    pub tdp1: Option<u32>,
+    pub tdp2: Option<u32>,
+    pub tdp0_range: Option<(u32, u32)>,
+    pub tdp1_range: Option<(u32, u32)>,
+    pub tdp2_range: Option<(u32, u32)>,
+    pub capabilities: CpuCapabilities,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CpuCapabilities {
+    pub has_boost: bool,
+    pub has_cpuinfo_max_freq: bool,
+    pub has_cpuinfo_min_freq: bool,
+    pub has_scaling_driver: bool,
+    pub has_energy_performance_preference: bool,
+    pub has_scaling_governor: bool,
+    pub has_smt: bool,
+    pub has_scaling_min_freq: bool,
+    pub has_scaling_max_freq: bool,
+    pub has_available_governors: bool,
+    pub has_amd_pstate: bool,
+    pub has_intel_pstate: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PowerSource {
+    pub name: String,      // e.g., "RAPL", "amdgpu", "zenpower"
+    pub value: f32,        // Power in watts
+    pub description: String,  // e.g., "Intel RAPL", "AMD APU (CPU+iGPU)", "Zenpower driver"
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CoreInfo {
+    pub id: u32,
+    pub frequency: u64,
+    pub load: f32,
+    pub temperature: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryInfo {
+    pub total_gib: f64,
+    pub used_gib: f64,
+    pub free_gib: f64,
+    pub available_gib: f64,
+    pub used_percent: f32,
+    pub memory_type: Option<String>,
+    pub memory_frequency: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -14,8 +104,8 @@ pub struct GpuInfo {
     pub frequency: Option<u64>,
     pub memory_frequency: Option<u64>,
     pub temperature: Option<f32>,
-    pub hotspot_temperature: Option<f32>,
-    pub memory_temperature: Option<f32>,
+    pub hotspot_temperature: Option<f32>,  // GPU hotspot/junction temperature
+    pub memory_temperature: Option<f32>,   // VRAM temperature
     pub load: Option<f32>,
     pub power: Option<f32>,
     pub voltage: Option<f32>,
@@ -37,167 +127,21 @@ pub struct GpuInfo {
     pub driver_version: Option<String>,
     pub supported_p_states: Vec<String>,
     pub supports_power_limit: bool,
-    pub power_limit_range: Option<(u32, u32)>,
+    pub power_limit_range: Option<(u32, u32)>, // in Watts
     pub supports_gpu_offset: bool,
     pub supports_mem_offset: bool,
-    pub fan_speed_range: Option<(u32, u32)>,
+    pub fan_speed_range: Option<(u32, u32)>, // in %
     pub vram_type: Option<String>,
     pub vram_vendor: Option<String>,
-    pub vram_bus_width: Option<u32>,
-    pub vram_bandwidth: Option<f32>,
-    pub vram_total: Option<u64>,
+    pub vram_bus_width: Option<u32>, // bits
+    pub vram_bandwidth: Option<f32>, // GB/s
+    pub vram_total: Option<u64>,     // MiB
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CpuInfo {
-    pub name: String,
-    pub average_frequency: u64,
-    pub average_load: f32,
-    pub package_temp: f32,
-    pub package_power: Option<f32>,
-    pub cores: Vec<CoreInfo>,
-    pub physical_cores: u32,
-    pub logical_cores: u32,
-    pub governor: String,
-    pub available_governors: Vec<String>,
-    pub boost_enabled: bool,
-    pub smt_enabled: bool,
-    pub scaling_driver: String,
-    pub amd_pstate_status: Option<String>,
-    pub intel_pstate_status: Option<String>,
-    pub min_freq: Option<u64>,
-    pub max_freq: Option<u64>,
-    pub hw_min_freq: Option<u64>,
-    pub hw_max_freq: Option<u64>,
-    pub all_power_sources: Vec<PowerSource>,
-    pub power_source: Option<String>,
-    pub energy_performance_preference: Option<String>,
-    pub available_epp_options: Vec<String>,
-    pub tdp0: Option<u32>,
-    pub tdp1: Option<u32>,
-    pub tdp2: Option<u32>,
-    pub tdp0_range: Option<(u32, u32)>,
-    pub tdp1_range: Option<(u32, u32)>,
-    pub tdp2_range: Option<(u32, u32)>,
-    pub capabilities: CpuCapabilities,
-    pub scheduler: String,
-    pub available_schedulers: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CoreInfo {
-    pub id: u32,
-    pub frequency: u64,
-    pub load: f32,
-    pub temperature: f32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct PowerSource {
-    pub name: String,
-    pub value: f32,
-    pub description: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CpuCapabilities {
-    pub has_boost: bool,
-    pub has_cpuinfo_max_freq: bool,
-    pub has_cpuinfo_min_freq: bool,
-    pub has_scaling_driver: bool,
-    pub has_energy_performance_preference: bool,
-    pub has_scaling_governor: bool,
-    pub has_smt: bool,
-    pub has_scaling_min_freq: bool,
-    pub has_scaling_max_freq: bool,
-    pub has_available_governors: bool,
-    pub has_amd_pstate: bool,
-    pub has_intel_pstate: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct MemoryInfo {
-    pub total_gib: f64,
-    pub used_gib: f64,
-    pub free_gib: f64,
-    pub available_gib: f64,
-    pub used_percent: f32,
-    pub memory_type: Option<String>,
-    pub memory_frequency: Option<u64>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct SystemInfo {
-    pub product_name: String,
-    pub product_sku: String,
-    pub manufacturer: String,
-    pub board_name: String,
-    pub bios_version: String,
-    pub kernel_modules: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct FanInfo {
-    pub id: u32,
-    pub name: String,
-    pub rpm_or_percent: u32,
-    pub temperature: Option<f32>,
-    pub is_rpm: bool,
-    pub mode: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct WiFiInfo {
-    pub interface: String,
-    pub driver: String,
-    pub driver_version: Option<String>,
-    pub firmware_version: Option<String>,
-    pub temperature: Option<f32>,
-    pub signal_level: Option<i32>,
-    pub channel: Option<u32>,
-    pub channel_width: Option<u32>,
-    pub channel_freq: Option<u32>,
-    pub tx_rate: Option<f64>,
-    pub rx_rate: Option<f64>,
-    pub ssid: Option<String>,
-    pub tx_bitrate: Option<f64>,
-    pub rx_bitrate: Option<f64>,
-    pub rx_bytes: Option<u64>,
-    pub tx_bytes: Option<u64>,
-    pub network_controller: Option<String>,
-    pub subsystem: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum ConnectionType {
-    Wired,
-    Wireless,
-    Unknown,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum PowerStatus {
-    Charging,
-    Discharging,
-    Full,
-    Unknown,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum GamepadStatus {
-    Connected,
-    Disconnected,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct GamepadInfo {
-    pub name: String,
-    pub id: String,
-    pub uid: String,
-    pub status: GamepadStatus,
-    pub battery_level: Option<u8>,
-    pub connection_type: ConnectionType,
-    pub power_status: PowerStatus,
+pub enum GpuType {
+    Integrated,
+    Discrete,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -215,12 +159,35 @@ pub struct BatteryInfo {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct MountInfo {
-    pub mount_point: String,
-    pub filesystem_type: String,
-    pub total_gb: u64,
-    pub used_gb: u64,
-    pub used_percent: f64,
+pub struct FanInfo {
+    pub id: u32,
+    pub name: String,
+    pub rpm_or_percent: u32,
+    pub temperature: Option<f32>,  // Temperature sensor for this fan
+    pub is_rpm: bool,              // true if rpm_or_percent is RPM, false if it's percentage
+    pub mode: Option<String>,      // "Auto", "Manual", etc.
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WiFiInfo {
+    pub interface: String,
+    pub driver: String,
+    pub driver_version: Option<String>,
+    pub firmware_version: Option<String>,
+    pub temperature: Option<f32>,
+    pub signal_level: Option<i32>,      // Signal level in dBm
+    pub channel: Option<u32>,           // Current channel
+    pub channel_width: Option<u32>,     // Channel width in MHz (20/40/80/160)
+    pub channel_freq: Option<u32>,      // Channel frequency in MHz
+    pub tx_rate: Option<f64>,           // Upload rate in Mbps (Actual throughput)
+    pub rx_rate: Option<f64>,           // Download rate in Mbps (Actual throughput)
+    pub ssid: Option<String>,
+    pub tx_bitrate: Option<f64>,        // Link speed in Mbps (PHY rate)
+    pub rx_bitrate: Option<f64>,        // Link speed in Mbps (PHY rate)
+    pub rx_bytes: Option<u64>,
+    pub tx_bytes: Option<u64>,
+    pub network_controller: Option<String>,
+    pub subsystem: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -235,12 +202,164 @@ pub struct StorageDevice {
     pub write_iops: Option<f64>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct GamepadInfo {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub id: String, // Dynamic identifier (e.g. input0)
+    #[serde(default)]
+    pub uid: String, // Stable unique identifier (e.g. ID_PATH from udev)
+    #[serde(default)]
+    pub status: GamepadStatus,
+    #[serde(default)]
+    pub battery_level: Option<u8>,
+    #[serde(default)]
+    pub connection_type: ConnectionType,
+    #[serde(default)]
+    pub power_status: PowerStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub enum GamepadStatus {
+    Connected,
+    #[default]
+    Disconnected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub enum ConnectionType {
+    Wired,
+    Wireless,
+    #[default]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub enum PowerStatus {
+    Charging,
+    Discharging,
+    Full,
+    #[default]
+    Unknown,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct LogEntry {
-    pub timestamp: String,
-    pub level: String,
-    pub target: String,
-    pub message: String,
+pub struct MountInfo {
+    pub mount_point: String,
+    pub filesystem_type: String,
+    pub total_gb: u64,
+    pub used_gb: u64,
+    pub used_percent: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Profile {
+    pub name: String,
+    pub is_default: bool,
+    pub cpu_settings: CpuSettings,
+    pub gpu_settings: GpuSettings,
+    pub keyboard_settings: KeyboardSettings,
+    pub screen_settings: ScreenSettings,
+    pub fan_settings: FanSettings,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CpuSettings {
+    pub governor: Option<String>,
+    pub min_frequency: Option<u64>,
+    pub max_frequency: Option<u64>,
+    pub boost: Option<bool>,
+    pub smt: Option<bool>,
+    pub performance_profile: Option<String>,
+    pub tdp_profile: Option<String>,
+    pub energy_performance_preference: Option<String>,
+    pub tdp: Option<u32>,
+    pub tdp0: Option<u32>,
+    pub tdp1: Option<u32>,
+    pub tdp2: Option<u32>,
+    pub amd_pstate_status: Option<String>,
+    pub intel_pstate_status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GpuSettings {
+    pub dgpu_tdp: Option<u32>,
+    pub min_gpu_clock: Option<u32>,
+    pub max_gpu_clock: Option<u32>,
+    pub min_mem_clock: Option<u32>,
+    pub max_mem_clock: Option<u32>,
+    pub manual_clocks: bool,
+    pub core_offset: Option<f32>,
+    pub memory_offset: Option<f32>,
+    pub power_limit: Option<u32>,
+    pub prime_profile: Option<String>,
+    #[serde(default)]
+    pub advanced_control: bool,
+    #[serde(default)]
+    pub advanced: GpuAdvancedSettings,
+    #[serde(default)]
+    pub advanced_min_gpu_clock: Option<u32>,
+    #[serde(default)]
+    pub advanced_max_gpu_clock: Option<u32>,
+    #[serde(default)]
+    pub advanced_min_mem_clock: Option<u32>,
+    #[serde(default)]
+    pub advanced_max_mem_clock: Option<u32>,
+    #[serde(default)]
+    pub advanced_memory_offset: Option<i32>,
+    #[serde(default)]
+    pub nvidia_fans: Vec<NvidiaFanSettings>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct NvidiaFanSettings {
+    pub device_index: u32,
+    pub fan_id: u32,
+    pub speed: u32,
+    pub manual: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GpuAdvancedSettings {
+    pub temperature_min: i32,
+    pub temperature_max: i32,
+    pub plimit_min: i32,
+    pub plimit_max: i32,
+    pub frequency_min: i32,
+    pub frequency_max: i32,
+    pub freq_offset_max: i32,
+    pub freq_offset_min: i32,
+    pub low_freq_min: i32,
+    pub low_freq_max: i32,
+    pub drain_offset_lmin: i32,
+    pub drain_offset_lmax: i32,
+    pub high_freq_min: i32,
+    pub high_freq_max: i32,
+    pub drain_offset_hmin: i32,
+    pub drain_offset_hmax: i32,
+    pub critical_temp_min: i32,
+    pub critical_temp_max: i32,
+    pub power_offset_max: i32,
+    pub power_offset_min: i32,
+    #[serde(default)]
+    pub drain_offset_control: bool,
+    #[serde(default)]
+    pub power_offset_control: bool,
+    #[serde(default)]
+    pub critical_temp_range_control: bool,
+    #[serde(default = "default_smart_rounding_threshold")]
+    pub smart_rounding_threshold: i32,
+}
+
+fn default_smart_rounding_threshold() -> i32 {
+    15
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct KeyboardSettings {
+    pub control_enabled: bool,
+    pub mode: KeyboardMode,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -284,133 +403,15 @@ pub enum KeyboardMode {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Profile {
-    pub name: String,
-    pub is_default: bool,
-    pub cpu_settings: CpuSettings,
-    pub gpu_settings: GpuSettings,
-    pub keyboard_settings: KeyboardSettings,
-    pub screen_settings: ScreenSettings,
-    pub fan_settings: FanSettings,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct CpuSettings {
-    pub governor: Option<String>,
-    pub min_frequency: Option<u64>,
-    pub max_frequency: Option<u64>,
-    pub boost: Option<bool>,
-    pub smt: Option<bool>,
-    pub performance_profile: Option<String>,
-    pub tdp_profile: Option<String>,
-    pub energy_performance_preference: Option<String>,
-    pub tdp: Option<u32>,
-    pub tdp0: Option<u32>,
-    pub tdp1: Option<u32>,
-    pub tdp2: Option<u32>,
-    pub amd_pstate_status: Option<String>,
-    pub intel_pstate_status: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct GpuSettings {
-    pub dgpu_tdp: Option<u32>,
-    pub min_gpu_clock: Option<u32>,
-    pub max_gpu_clock: Option<u32>,
-    pub min_mem_clock: Option<u32>,
-    pub max_mem_clock: Option<u32>,
-    pub manual_clocks: bool,
-    pub core_offset: Option<f32>,
-    pub memory_offset: Option<f32>,
-    pub power_limit: Option<u32>,
-    pub prime_profile: Option<String>,
-    #[serde(default)]
-    pub advanced_control: bool,
-    #[serde(default)]
-    pub advanced: GpuAdvancedSettings,
-    #[serde(default)]
-    pub advanced_min_gpu_clock: Option<u32>,
-    #[serde(default)]
-    pub advanced_max_gpu_clock: Option<u32>,
-    #[serde(default)]
-    pub advanced_min_mem_clock: Option<u32>,
-    #[serde(default)]
-    pub advanced_max_mem_clock: Option<u32>,
-    #[serde(default)]
-    pub advanced_memory_offset: Option<i32>,
-    #[serde(default)]
-    pub nvidia_fans: Vec<NvidiaFanSettings>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct NvidiaFanSettings {
-    pub device_index: u32,
-    pub fan_id: u32,
-    pub speed: u32,
-    pub manual: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct GpuAdvancedSettings {
-    pub temperature_min: i32,
-    pub temperature_max: i32,
-    pub plimit_min: i32,
-    pub plimit_max: i32,
-    pub frequency_min: i32,
-    pub frequency_max: i32,
-    pub freq_offset_max: i32,
-    pub freq_offset_min: i32,
-    pub low_freq_min: i32,
-    pub low_freq_max: i32,
-    pub drain_offset_lmin: i32,
-    pub drain_offset_lmax: i32,
-    pub high_freq_min: i32,
-    pub high_freq_max: i32,
-    pub drain_offset_hmin: i32,
-    pub drain_offset_hmax: i32,
-    pub critical_temp_min: i32,
-    pub critical_temp_max: i32,
-    pub power_offset_max: i32,
-    pub power_offset_min: i32,
-    pub drain_offset_control: bool,
-    pub power_offset_control: bool,
-    pub critical_temp_range_control: bool,
-    pub smart_rounding_threshold: i32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct KeyboardSettings {
-    pub control_enabled: bool,
-    pub mode: KeyboardMode,
-}
-
-impl Default for KeyboardMode {
-    fn default() -> Self {
-        KeyboardMode::SingleColor {
-            r: 255,
-            g: 255,
-            b: 255,
-            brightness: 50,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ScreenSettings {
     pub brightness: u8,
     pub system_control: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FanSettings {
     pub control_enabled: bool,
     pub curves: Vec<FanCurve>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct FanCurve {
-    pub fan_id: u32,
-    pub points: Vec<(u8, u8)>, // (temperature, speed) - 8 points
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -420,14 +421,10 @@ pub struct BatterySettings {
     pub charge_end_threshold: u8,
 }
 
-impl Default for BatterySettings {
-    fn default() -> Self {
-        Self {
-            control_enabled: false,
-            charge_start_threshold: 40,
-            charge_end_threshold: 80,
-        }
-    }
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FanCurve {
+    pub fan_id: u32,
+    pub points: Vec<(u8, u8)>, // (temperature, speed) - 8 points
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -550,6 +547,16 @@ impl Default for AppConfig {
     }
 }
 
+impl Default for BatterySettings {
+    fn default() -> Self {
+        Self {
+            control_enabled: false,
+            charge_start_threshold: 40,
+            charge_end_threshold: 80,
+        }
+    }
+}
+
 impl Default for StatisticsSections {
     fn default() -> Self {
         Self {
@@ -596,6 +603,115 @@ impl Default for Profile {
             keyboard_settings: KeyboardSettings::default(),
             screen_settings: ScreenSettings::default(),
             fan_settings: FanSettings::default(),
+        }
+    }
+}
+
+impl Default for CpuSettings {
+    fn default() -> Self {
+        Self {
+            governor: None,
+            min_frequency: None,
+            max_frequency: None,
+            boost: None,
+            smt: None,
+            performance_profile: None,
+            tdp: None,
+            amd_pstate_status: None,
+            intel_pstate_status: None,
+            tdp_profile: None,
+            energy_performance_preference: None,
+            tdp0: None,
+            tdp1: None,
+            tdp2: None,
+        }
+    }
+}
+
+impl Default for GpuSettings {
+    fn default() -> Self {
+        Self {
+            dgpu_tdp: None,
+            min_gpu_clock: None,
+            max_gpu_clock: None,
+            min_mem_clock: None,
+            max_mem_clock: None,
+            manual_clocks: false,
+            core_offset: Some(0.0),
+            memory_offset: Some(0.0),
+            power_limit: None,
+            prime_profile: Some("on-demand".to_string()),
+            advanced_control: false,
+            advanced: GpuAdvancedSettings::default(),
+            advanced_min_gpu_clock: None,
+            advanced_max_gpu_clock: None,
+            advanced_min_mem_clock: None,
+            advanced_max_mem_clock: None,
+            advanced_memory_offset: Some(0),
+            nvidia_fans: vec![],
+        }
+    }
+}
+
+impl Default for GpuAdvancedSettings {
+    fn default() -> Self {
+        Self {
+            temperature_min: 20,
+            temperature_max: 80,
+            plimit_min: 20,
+            plimit_max: 120,
+            frequency_min: 900,
+            frequency_max: 1800,
+            freq_offset_max: 300,
+            freq_offset_min: 150,
+            low_freq_min: 1000,
+            low_freq_max: 1440,
+            drain_offset_lmin: -30,
+            drain_offset_lmax: 0,
+            high_freq_min: 1440,
+            high_freq_max: 1800,
+            drain_offset_hmin: 0,
+            drain_offset_hmax: 15,
+            critical_temp_min: 48,
+            critical_temp_max: 61,
+            power_offset_max: 35,
+            power_offset_min: 0,
+            drain_offset_control: false,
+            power_offset_control: false,
+            critical_temp_range_control: false,
+            smart_rounding_threshold: 15,
+        }
+    }
+}
+
+impl Default for KeyboardSettings {
+    fn default() -> Self {
+        Self {
+            control_enabled: false,
+            mode: KeyboardMode::SingleColor {
+                r: 255,
+                g: 255,
+                b: 255,
+                brightness: 50,
+            },
+        }
+    }
+}
+
+impl Default for ScreenSettings {
+    fn default() -> Self {
+        Self {
+            brightness: 50,
+            system_control: true,
+        }
+    }
+}
+
+impl Default for FanSettings {
+    fn default() -> Self {
+        Self {
+            control_enabled: false,
+            curves: vec![],
         }
     }
 }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,102 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SystemInfo {
-    pub product_name: String,
-    pub product_sku: String,
-    pub manufacturer: String,
-    pub board_name: String,
-    pub bios_version: String,
-    pub kernel_modules: String,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum GpuType {
+    Integrated,
+    Discrete,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LogEntry {
-    pub level: String,
-    pub target: String,
-    pub message: String,
-    pub timestamp: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CpuInfo {
-    pub name: String,
-    pub average_frequency: u64,
-    pub average_load: f32,
-    pub package_temp: f32,
-    pub package_power: Option<f32>,
-    pub power_source: Option<String>,
-    pub all_power_sources: Vec<PowerSource>,
-    pub cores: Vec<CoreInfo>,
-    pub physical_cores: u32,
-    pub logical_cores: u32,
-    pub governor: String,
-    pub available_governors: Vec<String>,
-    pub boost_enabled: bool,
-    pub smt_enabled: bool,
-    pub scaling_driver: String,
-    pub amd_pstate_status: Option<String>,
-    pub intel_pstate_status: Option<String>,
-    pub min_freq: Option<u64>,
-    pub max_freq: Option<u64>,
-    pub hw_min_freq: Option<u64>,
-    pub hw_max_freq: Option<u64>,
-    pub energy_performance_preference: Option<String>,
-    pub available_epp_options: Vec<String>,
-    pub scheduler: String,
-    pub available_schedulers: Vec<String>,
-    pub tdp0: Option<u32>,
-    pub tdp1: Option<u32>,
-    pub tdp2: Option<u32>,
-    pub tdp0_range: Option<(u32, u32)>,
-    pub tdp1_range: Option<(u32, u32)>,
-    pub tdp2_range: Option<(u32, u32)>,
-    pub capabilities: CpuCapabilities,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CpuCapabilities {
-    pub has_boost: bool,
-    pub has_cpuinfo_max_freq: bool,
-    pub has_cpuinfo_min_freq: bool,
-    pub has_scaling_driver: bool,
-    pub has_energy_performance_preference: bool,
-    pub has_scaling_governor: bool,
-    pub has_smt: bool,
-    pub has_scaling_min_freq: bool,
-    pub has_scaling_max_freq: bool,
-    pub has_available_governors: bool,
-    pub has_amd_pstate: bool,
-    pub has_intel_pstate: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PowerSource {
-    pub name: String,      // e.g., "RAPL", "amdgpu", "zenpower"
-    pub value: f32,        // Power in watts
-    pub description: String,  // e.g., "Intel RAPL", "AMD APU (CPU+iGPU)", "Zenpower driver"
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CoreInfo {
-    pub id: u32,
-    pub frequency: u64,
-    pub load: f32,
-    pub temperature: f32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MemoryInfo {
-    pub total_gib: f64,
-    pub used_gib: f64,
-    pub free_gib: f64,
-    pub available_gib: f64,
-    pub used_percent: f32,
-    pub memory_type: Option<String>,
-    pub memory_frequency: Option<u64>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GpuInfo {
     pub name: String,
     pub gpu_type: GpuType,
@@ -104,8 +14,8 @@ pub struct GpuInfo {
     pub frequency: Option<u64>,
     pub memory_frequency: Option<u64>,
     pub temperature: Option<f32>,
-    pub hotspot_temperature: Option<f32>,  // GPU hotspot/junction temperature
-    pub memory_temperature: Option<f32>,   // VRAM temperature
+    pub hotspot_temperature: Option<f32>,
+    pub memory_temperature: Option<f32>,
     pub load: Option<f32>,
     pub power: Option<f32>,
     pub voltage: Option<f32>,
@@ -127,24 +37,170 @@ pub struct GpuInfo {
     pub driver_version: Option<String>,
     pub supported_p_states: Vec<String>,
     pub supports_power_limit: bool,
-    pub power_limit_range: Option<(u32, u32)>, // in Watts
+    pub power_limit_range: Option<(u32, u32)>,
     pub supports_gpu_offset: bool,
     pub supports_mem_offset: bool,
-    pub fan_speed_range: Option<(u32, u32)>, // in %
+    pub fan_speed_range: Option<(u32, u32)>,
     pub vram_type: Option<String>,
     pub vram_vendor: Option<String>,
-    pub vram_bus_width: Option<u32>, // bits
-    pub vram_bandwidth: Option<f32>, // GB/s
-    pub vram_total: Option<u64>,     // MiB
+    pub vram_bus_width: Option<u32>,
+    pub vram_bandwidth: Option<f32>,
+    pub vram_total: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum GpuType {
-    Integrated,
-    Discrete,
+pub struct CpuInfo {
+    pub name: String,
+    pub average_frequency: u64,
+    pub average_load: f32,
+    pub package_temp: f32,
+    pub package_power: Option<f32>,
+    pub cores: Vec<CoreInfo>,
+    pub physical_cores: u32,
+    pub logical_cores: u32,
+    pub governor: String,
+    pub available_governors: Vec<String>,
+    pub boost_enabled: bool,
+    pub smt_enabled: bool,
+    pub scaling_driver: String,
+    pub amd_pstate_status: Option<String>,
+    pub intel_pstate_status: Option<String>,
+    pub min_freq: Option<u64>,
+    pub max_freq: Option<u64>,
+    pub hw_min_freq: Option<u64>,
+    pub hw_max_freq: Option<u64>,
+    pub all_power_sources: Vec<PowerSource>,
+    pub power_source: Option<String>,
+    pub energy_performance_preference: Option<String>,
+    pub available_epp_options: Vec<String>,
+    pub tdp0: Option<u32>,
+    pub tdp1: Option<u32>,
+    pub tdp2: Option<u32>,
+    pub tdp0_range: Option<(u32, u32)>,
+    pub tdp1_range: Option<(u32, u32)>,
+    pub tdp2_range: Option<(u32, u32)>,
+    pub capabilities: CpuCapabilities,
+    pub scheduler: String,
+    pub available_schedulers: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CoreInfo {
+    pub id: u32,
+    pub frequency: u64,
+    pub load: f32,
+    pub temperature: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PowerSource {
+    pub name: String,
+    pub value: f32,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CpuCapabilities {
+    pub has_boost: bool,
+    pub has_cpuinfo_max_freq: bool,
+    pub has_cpuinfo_min_freq: bool,
+    pub has_scaling_driver: bool,
+    pub has_energy_performance_preference: bool,
+    pub has_scaling_governor: bool,
+    pub has_smt: bool,
+    pub has_scaling_min_freq: bool,
+    pub has_scaling_max_freq: bool,
+    pub has_available_governors: bool,
+    pub has_amd_pstate: bool,
+    pub has_intel_pstate: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryInfo {
+    pub total_gib: f64,
+    pub used_gib: f64,
+    pub free_gib: f64,
+    pub available_gib: f64,
+    pub used_percent: f32,
+    pub memory_type: Option<String>,
+    pub memory_frequency: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SystemInfo {
+    pub product_name: String,
+    pub product_sku: String,
+    pub manufacturer: String,
+    pub board_name: String,
+    pub bios_version: String,
+    pub kernel_modules: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FanInfo {
+    pub id: u32,
+    pub name: String,
+    pub rpm_or_percent: u32,
+    pub temperature: Option<f32>,
+    pub is_rpm: bool,
+    pub mode: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WiFiInfo {
+    pub interface: String,
+    pub driver: String,
+    pub driver_version: Option<String>,
+    pub firmware_version: Option<String>,
+    pub temperature: Option<f32>,
+    pub signal_level: Option<i32>,
+    pub channel: Option<u32>,
+    pub channel_width: Option<u32>,
+    pub channel_freq: Option<u32>,
+    pub tx_rate: Option<f64>,
+    pub rx_rate: Option<f64>,
+    pub ssid: Option<String>,
+    pub tx_bitrate: Option<f64>,
+    pub rx_bitrate: Option<f64>,
+    pub rx_bytes: Option<u64>,
+    pub tx_bytes: Option<u64>,
+    pub network_controller: Option<String>,
+    pub subsystem: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ConnectionType {
+    Wired,
+    Wireless,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum PowerStatus {
+    Charging,
+    Discharging,
+    Full,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum GamepadStatus {
+    Connected,
+    Disconnected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GamepadInfo {
+    pub name: String,
+    pub id: String,
+    pub uid: String,
+    pub status: GamepadStatus,
+    pub battery_level: Option<u8>,
+    pub connection_type: ConnectionType,
+    pub power_status: PowerStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BatteryInfo {
     pub status: String,
     pub voltage_mv: u64,
@@ -158,39 +214,16 @@ pub struct BatteryInfo {
     pub charge_end_threshold: Option<u8>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FanInfo {
-    pub id: u32,
-    pub name: String,
-    pub rpm_or_percent: u32,
-    pub temperature: Option<f32>,  // Temperature sensor for this fan
-    pub is_rpm: bool,              // true if rpm_or_percent is RPM, false if it's percentage
-    pub mode: Option<String>,      // "Auto", "Manual", etc.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MountInfo {
+    pub mount_point: String,
+    pub filesystem_type: String,
+    pub total_gb: u64,
+    pub used_gb: u64,
+    pub used_percent: f64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WiFiInfo {
-    pub interface: String,
-    pub driver: String,
-    pub driver_version: Option<String>,
-    pub firmware_version: Option<String>,
-    pub temperature: Option<f32>,
-    pub signal_level: Option<i32>,      // Signal level in dBm
-    pub channel: Option<u32>,           // Current channel
-    pub channel_width: Option<u32>,     // Channel width in MHz (20/40/80/160)
-    pub channel_freq: Option<u32>,      // Channel frequency in MHz
-    pub tx_rate: Option<f64>,           // Upload rate in Mbps (Actual throughput)
-    pub rx_rate: Option<f64>,           // Download rate in Mbps (Actual throughput)
-    pub ssid: Option<String>,
-    pub tx_bitrate: Option<f64>,        // Link speed in Mbps (PHY rate)
-    pub rx_bitrate: Option<f64>,        // Link speed in Mbps (PHY rate)
-    pub rx_bytes: Option<u64>,
-    pub tx_bytes: Option<u64>,
-    pub network_controller: Option<String>,
-    pub subsystem: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StorageDevice {
     pub device: String,
     pub model: String,
@@ -202,164 +235,12 @@ pub struct StorageDevice {
     pub write_iops: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct GamepadInfo {
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub id: String, // Dynamic identifier (e.g. input0)
-    #[serde(default)]
-    pub uid: String, // Stable unique identifier (e.g. ID_PATH from udev)
-    #[serde(default)]
-    pub status: GamepadStatus,
-    #[serde(default)]
-    pub battery_level: Option<u8>,
-    #[serde(default)]
-    pub connection_type: ConnectionType,
-    #[serde(default)]
-    pub power_status: PowerStatus,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub enum GamepadStatus {
-    Connected,
-    #[default]
-    Disconnected,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub enum ConnectionType {
-    Wired,
-    Wireless,
-    #[default]
-    Unknown,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub enum PowerStatus {
-    Charging,
-    Discharging,
-    Full,
-    #[default]
-    Unknown,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MountInfo {
-    pub mount_point: String,
-    pub filesystem_type: String,
-    pub total_gb: u64,
-    pub used_gb: u64,
-    pub used_percent: f64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Profile {
-    pub name: String,
-    pub is_default: bool,
-    pub cpu_settings: CpuSettings,
-    pub gpu_settings: GpuSettings,
-    pub keyboard_settings: KeyboardSettings,
-    pub screen_settings: ScreenSettings,
-    pub fan_settings: FanSettings,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CpuSettings {
-    pub governor: Option<String>,
-    pub min_frequency: Option<u64>,
-    pub max_frequency: Option<u64>,
-    pub boost: Option<bool>,
-    pub smt: Option<bool>,
-    pub performance_profile: Option<String>,
-    pub tdp_profile: Option<String>,
-    pub energy_performance_preference: Option<String>,
-    pub tdp: Option<u32>,
-    pub tdp0: Option<u32>,
-    pub tdp1: Option<u32>,
-    pub tdp2: Option<u32>,
-    pub amd_pstate_status: Option<String>,
-    pub intel_pstate_status: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GpuSettings {
-    pub dgpu_tdp: Option<u32>,
-    pub min_gpu_clock: Option<u32>,
-    pub max_gpu_clock: Option<u32>,
-    pub min_mem_clock: Option<u32>,
-    pub max_mem_clock: Option<u32>,
-    pub manual_clocks: bool,
-    pub core_offset: Option<f32>,
-    pub memory_offset: Option<f32>,
-    pub power_limit: Option<u32>,
-    pub prime_profile: Option<String>,
-    #[serde(default)]
-    pub advanced_control: bool,
-    #[serde(default)]
-    pub advanced: GpuAdvancedSettings,
-    #[serde(default)]
-    pub advanced_min_gpu_clock: Option<u32>,
-    #[serde(default)]
-    pub advanced_max_gpu_clock: Option<u32>,
-    #[serde(default)]
-    pub advanced_min_mem_clock: Option<u32>,
-    #[serde(default)]
-    pub advanced_max_mem_clock: Option<u32>,
-    #[serde(default)]
-    pub advanced_memory_offset: Option<i32>,
-    #[serde(default)]
-    pub nvidia_fans: Vec<NvidiaFanSettings>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
-pub struct NvidiaFanSettings {
-    pub device_index: u32,
-    pub fan_id: u32,
-    pub speed: u32,
-    pub manual: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GpuAdvancedSettings {
-    pub temperature_min: i32,
-    pub temperature_max: i32,
-    pub plimit_min: i32,
-    pub plimit_max: i32,
-    pub frequency_min: i32,
-    pub frequency_max: i32,
-    pub freq_offset_max: i32,
-    pub freq_offset_min: i32,
-    pub low_freq_min: i32,
-    pub low_freq_max: i32,
-    pub drain_offset_lmin: i32,
-    pub drain_offset_lmax: i32,
-    pub high_freq_min: i32,
-    pub high_freq_max: i32,
-    pub drain_offset_hmin: i32,
-    pub drain_offset_hmax: i32,
-    pub critical_temp_min: i32,
-    pub critical_temp_max: i32,
-    pub power_offset_max: i32,
-    pub power_offset_min: i32,
-    #[serde(default)]
-    pub drain_offset_control: bool,
-    #[serde(default)]
-    pub power_offset_control: bool,
-    #[serde(default)]
-    pub critical_temp_range_control: bool,
-    #[serde(default = "default_smart_rounding_threshold")]
-    pub smart_rounding_threshold: i32,
-}
-
-fn default_smart_rounding_threshold() -> i32 {
-    15
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct KeyboardSettings {
-    pub control_enabled: bool,
-    pub mode: KeyboardMode,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LogEntry {
+    pub timestamp: String,
+    pub level: String,
+    pub target: String,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -402,32 +283,154 @@ pub enum KeyboardMode {
     Wave { brightness: u8, speed: u8 },  // WAVE (7)
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Profile {
+    pub name: String,
+    pub is_default: bool,
+    pub cpu_settings: CpuSettings,
+    pub gpu_settings: GpuSettings,
+    pub keyboard_settings: KeyboardSettings,
+    pub screen_settings: ScreenSettings,
+    pub fan_settings: FanSettings,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct CpuSettings {
+    pub governor: Option<String>,
+    pub min_frequency: Option<u64>,
+    pub max_frequency: Option<u64>,
+    pub boost: Option<bool>,
+    pub smt: Option<bool>,
+    pub performance_profile: Option<String>,
+    pub tdp_profile: Option<String>,
+    pub energy_performance_preference: Option<String>,
+    pub tdp: Option<u32>,
+    pub tdp0: Option<u32>,
+    pub tdp1: Option<u32>,
+    pub tdp2: Option<u32>,
+    pub amd_pstate_status: Option<String>,
+    pub intel_pstate_status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct GpuSettings {
+    pub dgpu_tdp: Option<u32>,
+    pub min_gpu_clock: Option<u32>,
+    pub max_gpu_clock: Option<u32>,
+    pub min_mem_clock: Option<u32>,
+    pub max_mem_clock: Option<u32>,
+    pub manual_clocks: bool,
+    pub core_offset: Option<f32>,
+    pub memory_offset: Option<f32>,
+    pub power_limit: Option<u32>,
+    pub prime_profile: Option<String>,
+    #[serde(default)]
+    pub advanced_control: bool,
+    #[serde(default)]
+    pub advanced: GpuAdvancedSettings,
+    #[serde(default)]
+    pub advanced_min_gpu_clock: Option<u32>,
+    #[serde(default)]
+    pub advanced_max_gpu_clock: Option<u32>,
+    #[serde(default)]
+    pub advanced_min_mem_clock: Option<u32>,
+    #[serde(default)]
+    pub advanced_max_mem_clock: Option<u32>,
+    #[serde(default)]
+    pub advanced_memory_offset: Option<i32>,
+    #[serde(default)]
+    pub nvidia_fans: Vec<NvidiaFanSettings>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct NvidiaFanSettings {
+    pub device_index: u32,
+    pub fan_id: u32,
+    pub speed: u32,
+    pub manual: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct GpuAdvancedSettings {
+    pub temperature_min: i32,
+    pub temperature_max: i32,
+    pub plimit_min: i32,
+    pub plimit_max: i32,
+    pub frequency_min: i32,
+    pub frequency_max: i32,
+    pub freq_offset_max: i32,
+    pub freq_offset_min: i32,
+    pub low_freq_min: i32,
+    pub low_freq_max: i32,
+    pub drain_offset_lmin: i32,
+    pub drain_offset_lmax: i32,
+    pub high_freq_min: i32,
+    pub high_freq_max: i32,
+    pub drain_offset_hmin: i32,
+    pub drain_offset_hmax: i32,
+    pub critical_temp_min: i32,
+    pub critical_temp_max: i32,
+    pub power_offset_max: i32,
+    pub power_offset_min: i32,
+    pub drain_offset_control: bool,
+    pub power_offset_control: bool,
+    pub critical_temp_range_control: bool,
+    pub smart_rounding_threshold: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct KeyboardSettings {
+    pub control_enabled: bool,
+    pub mode: KeyboardMode,
+}
+
+impl Default for KeyboardMode {
+    fn default() -> Self {
+        KeyboardMode::SingleColor {
+            r: 255,
+            g: 255,
+            b: 255,
+            brightness: 50,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ScreenSettings {
     pub brightness: u8,
     pub system_control: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct FanSettings {
     pub control_enabled: bool,
     pub curves: Vec<FanCurve>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct FanCurve {
+    pub fan_id: u32,
+    pub points: Vec<(u8, u8)>, // (temperature, speed) - 8 points
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BatterySettings {
     pub control_enabled: bool,
     pub charge_start_threshold: u8,
     pub charge_end_threshold: u8,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct FanCurve {
-    pub fan_id: u32,
-    pub points: Vec<(u8, u8)>, // (temperature, speed) - 8 points
+impl Default for BatterySettings {
+    fn default() -> Self {
+        Self {
+            control_enabled: false,
+            charge_start_threshold: 40,
+            charge_end_threshold: 80,
+        }
+    }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AppConfig {
     pub theme: Theme,
     pub start_minimized: bool,
@@ -471,7 +474,7 @@ pub enum Theme {
     Dark,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StatisticsSections {
     pub show_system_info: bool,
     pub show_cpu: bool,
@@ -547,16 +550,6 @@ impl Default for AppConfig {
     }
 }
 
-impl Default for BatterySettings {
-    fn default() -> Self {
-        Self {
-            control_enabled: false,
-            charge_start_threshold: 40,
-            charge_end_threshold: 80,
-        }
-    }
-}
-
 impl Default for StatisticsSections {
     fn default() -> Self {
         Self {
@@ -603,115 +596,6 @@ impl Default for Profile {
             keyboard_settings: KeyboardSettings::default(),
             screen_settings: ScreenSettings::default(),
             fan_settings: FanSettings::default(),
-        }
-    }
-}
-
-impl Default for CpuSettings {
-    fn default() -> Self {
-        Self {
-            governor: None,
-            min_frequency: None,
-            max_frequency: None,
-            boost: None,
-            smt: None,
-            performance_profile: None,
-            tdp: None,
-            amd_pstate_status: None,
-            intel_pstate_status: None,
-            tdp_profile: None,
-            energy_performance_preference: None,
-            tdp0: None,
-            tdp1: None,
-            tdp2: None,
-        }
-    }
-}
-
-impl Default for GpuSettings {
-    fn default() -> Self {
-        Self {
-            dgpu_tdp: None,
-            min_gpu_clock: None,
-            max_gpu_clock: None,
-            min_mem_clock: None,
-            max_mem_clock: None,
-            manual_clocks: false,
-            core_offset: Some(0.0),
-            memory_offset: Some(0.0),
-            power_limit: None,
-            prime_profile: Some("on-demand".to_string()),
-            advanced_control: false,
-            advanced: GpuAdvancedSettings::default(),
-            advanced_min_gpu_clock: None,
-            advanced_max_gpu_clock: None,
-            advanced_min_mem_clock: None,
-            advanced_max_mem_clock: None,
-            advanced_memory_offset: Some(0),
-            nvidia_fans: vec![],
-        }
-    }
-}
-
-impl Default for GpuAdvancedSettings {
-    fn default() -> Self {
-        Self {
-            temperature_min: 20,
-            temperature_max: 80,
-            plimit_min: 20,
-            plimit_max: 120,
-            frequency_min: 900,
-            frequency_max: 1800,
-            freq_offset_max: 300,
-            freq_offset_min: 150,
-            low_freq_min: 1000,
-            low_freq_max: 1440,
-            drain_offset_lmin: -30,
-            drain_offset_lmax: 0,
-            high_freq_min: 1440,
-            high_freq_max: 1800,
-            drain_offset_hmin: 0,
-            drain_offset_hmax: 15,
-            critical_temp_min: 48,
-            critical_temp_max: 61,
-            power_offset_max: 35,
-            power_offset_min: 0,
-            drain_offset_control: false,
-            power_offset_control: false,
-            critical_temp_range_control: false,
-            smart_rounding_threshold: 15,
-        }
-    }
-}
-
-impl Default for KeyboardSettings {
-    fn default() -> Self {
-        Self {
-            control_enabled: false,
-            mode: KeyboardMode::SingleColor {
-                r: 255,
-                g: 255,
-                b: 255,
-                brightness: 50,
-            },
-        }
-    }
-}
-
-impl Default for ScreenSettings {
-    fn default() -> Self {
-        Self {
-            brightness: 50,
-            system_control: true,
-        }
-    }
-}
-
-impl Default for FanSettings {
-    fn default() -> Self {
-        Self {
-            control_enabled: false,
-            curves: vec![],
         }
     }
 }

--- a/daemon/src/dbus_interface.rs
+++ b/daemon/src/dbus_interface.rs
@@ -190,7 +190,7 @@ impl ControlInterface {
     }
 
     async fn apply_profile(&self, profile_json: &str) -> Result<(), zbus::fdo::Error> {
-        log::info!(target: "api.call", "ApplyProfile");
+        log::debug!(target: "api.call", "ApplyProfile");
         let start = std::time::Instant::now();
         let res = (|| async {
             let profile: Profile = serde_json::from_str(profile_json)?;
@@ -204,7 +204,7 @@ impl ControlInterface {
 
         let duration = start.elapsed().as_millis();
         match &res {
-            Ok(_) => log::info!(target: "api.ok", "ApplyProfile duration_ms={}", duration),
+            Ok(_) => log::debug!(target: "api.ok", "ApplyProfile duration_ms={}", duration),
             Err(e) => log::warn!(target: "api.fail", "ApplyProfile reason=\"{}\" duration_ms={}", e, duration),
         }
         res.map_err(|e| zbus::fdo::Error::Failed(e.to_string()))

--- a/daemon/src/hardware_control.rs
+++ b/daemon/src/hardware_control.rs
@@ -29,6 +29,7 @@ pub fn set_cpu_governor(governor: &str) -> Result<()> {
     }
     
     log::info!(target: "hw.cpu", "set_governor profile=\"{}\"", governor);
+    crate::refresh_hardware_cache();
     Ok(())
 }
 
@@ -141,6 +142,7 @@ pub fn set_amd_pstate_status(status: &str) -> Result<()> {
     
     fs::write(path, status)?;
     log::info!(target: "hw.cpu", "set_amd_pstate_status status=\"{}\"", status);
+    crate::refresh_hardware_cache();
     Ok(())
 }
 
@@ -156,6 +158,7 @@ pub fn set_intel_pstate_status(status: &str) -> Result<()> {
 
     fs::write(path, status)?;
     log::info!(target: "hw.cpu", "set_intel_pstate_status status=\"{}\"", status);
+    crate::refresh_hardware_cache();
     Ok(())
 }
 

--- a/daemon/src/hardware_control.rs
+++ b/daemon/src/hardware_control.rs
@@ -3,12 +3,13 @@ use nvml_wrapper::Nvml;
 use once_cell::sync::Lazy;
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 use lapsphere_common::types::*;
 use crate::tuxedo_io::{TuxedoIo, HardwareInterface};
 
 static CPU_LIMITS_MODIFIED: AtomicBool = AtomicBool::new(false);
+static LAST_APPLIED_PROFILE: Lazy<Mutex<Option<Profile>>> = Lazy::new(|| Mutex::new(None));
 
 fn get_cpu_count() -> Result<u32> {
     let cpuinfo = fs::read_to_string("/proc/cpuinfo")?;
@@ -159,6 +160,18 @@ pub fn set_intel_pstate_status(status: &str) -> Result<()> {
 }
 
 pub fn apply_profile(profile: &Profile) -> Result<()> {
+    // Check if this profile is already applied to avoid redundant hardware calls
+    {
+        let mut last_profile = LAST_APPLIED_PROFILE.lock().unwrap();
+        if let Some(ref last) = *last_profile {
+            if last == profile {
+                log::info!(target: "hw.detect", "Profile '{}' is already applied, skipping", profile.name);
+                return Ok(());
+            }
+        }
+        *last_profile = Some(profile.clone());
+    }
+
     log::info!(target: "hw.detect", "Applying profile: {}", profile.name);
     
     // Apply CPU settings
@@ -200,9 +213,31 @@ pub fn apply_profile(profile: &Profile) -> Result<()> {
         set_cpu_frequency_limits(min, max)?;
     }
 
+    // Apply GPU settings
+    let nvidia_gpu_idx = {
+        let cache = crate::HARDWARE_CACHE.lock().unwrap();
+        cache.gpu_info.iter()
+            .find(|g| g.name.to_lowercase().contains("nvidia"))
+            .and_then(|g| g.nvml_index)
+            .unwrap_or(0)
+    };
+
     if let Some(limit) = profile.gpu_settings.power_limit {
-        let nvidia_gpu_idx = profile.gpu_settings.nvidia_fans.get(0).map(|f| f.device_index).unwrap_or(0);
         let _ = set_gpu_power_limit(nvidia_gpu_idx, limit);
+    }
+
+    if let Some(core_offset) = profile.gpu_settings.core_offset {
+        let _ = set_gpu_core_offset(nvidia_gpu_idx, core_offset as f32);
+    }
+
+    if let Some(memory_offset) = profile.gpu_settings.memory_offset {
+        let _ = set_gpu_memory_offset(nvidia_gpu_idx, memory_offset as f32);
+    }
+
+    if let (Some(min_clock), Some(max_clock)) = (profile.gpu_settings.min_gpu_clock, profile.gpu_settings.max_gpu_clock) {
+        let _ = set_gpu_locked_clocks(nvidia_gpu_idx, min_clock, max_clock);
+    } else {
+        let _ = reset_gpu_clocks(nvidia_gpu_idx);
     }
     
     if let Some(boost) = profile.cpu_settings.boost {

--- a/daemon/src/hardware_control.rs
+++ b/daemon/src/hardware_control.rs
@@ -27,7 +27,7 @@ pub fn set_cpu_governor(governor: &str) -> Result<()> {
             .map_err(|e| anyhow!("Failed to set governor for CPU {}: {}", i, e))?;
     }
     
-    log::debug!(target: "hw.cpu", "set_governor profile=\"{}\"", governor);
+    log::info!(target: "hw.cpu", "set_governor profile=\"{}\"", governor);
     Ok(())
 }
 
@@ -70,7 +70,7 @@ pub fn set_cpu_frequency_limits(min_freq: u64, max_freq: u64) -> Result<()> {
     }
     
     CPU_LIMITS_MODIFIED.store(true, Ordering::SeqCst);
-    log::debug!(target: "hw.cpu", "set_freq_limits min={} max={}", min_freq, max_freq);
+    log::info!(target: "hw.cpu", "set_freq_limits min={} max={}", min_freq, max_freq);
     Ok(())
 }
 
@@ -94,7 +94,7 @@ pub fn set_cpu_boost(enabled: bool) -> Result<()> {
     let amd_path = "/sys/devices/system/cpu/cpufreq/boost";
     if Path::new(amd_path).exists() {
         fs::write(amd_path, if enabled { "1" } else { "0" })?;
-        log::debug!(target: "hw.cpu", "set_amd_boost enabled={}", enabled);
+        log::info!(target: "hw.cpu", "set_amd_boost enabled={}", enabled);
         return Ok(());
     }
     
@@ -102,7 +102,7 @@ pub fn set_cpu_boost(enabled: bool) -> Result<()> {
     let intel_path = "/sys/devices/system/cpu/intel_pstate/no_turbo";
     if Path::new(intel_path).exists() {
         fs::write(intel_path, if enabled { "0" } else { "1" })?;
-        log::debug!(target: "hw.cpu", "set_intel_turbo enabled={}", enabled);
+        log::info!(target: "hw.cpu", "set_intel_turbo enabled={}", enabled);
         return Ok(());
     }
     
@@ -110,7 +110,7 @@ pub fn set_cpu_boost(enabled: bool) -> Result<()> {
     let amd_pstate_boost = "/sys/devices/system/cpu/amd_pstate/cpb_boost";
     if Path::new(amd_pstate_boost).exists() {
         fs::write(amd_pstate_boost, if enabled { "1" } else { "0" })?;
-        log::debug!(target: "hw.cpu", "set_amd_pstate_boost enabled={}", enabled);
+        log::info!(target: "hw.cpu", "set_amd_pstate_boost enabled={}", enabled);
         return Ok(());
     }
     
@@ -124,7 +124,7 @@ pub fn set_smt(enabled: bool) -> Result<()> {
     }
     
     fs::write(path, if enabled { "on" } else { "off" })?;
-    log::debug!(target: "hw.cpu", "set_smt enabled={}", enabled);
+    log::info!(target: "hw.cpu", "set_smt enabled={}", enabled);
     Ok(())
 }
 
@@ -139,7 +139,7 @@ pub fn set_amd_pstate_status(status: &str) -> Result<()> {
     }
     
     fs::write(path, status)?;
-    log::debug!(target: "hw.cpu", "set_amd_pstate_status status=\"{}\"", status);
+    log::info!(target: "hw.cpu", "set_amd_pstate_status status=\"{}\"", status);
     Ok(())
 }
 
@@ -154,7 +154,7 @@ pub fn set_intel_pstate_status(status: &str) -> Result<()> {
     }
 
     fs::write(path, status)?;
-    log::debug!(target: "hw.cpu", "set_intel_pstate_status status=\"{}\"", status);
+    log::info!(target: "hw.cpu", "set_intel_pstate_status status=\"{}\"", status);
     Ok(())
 }
 
@@ -237,7 +237,7 @@ pub fn apply_profile(profile: &Profile) -> Result<()> {
 
 pub fn apply_battery_settings(settings: &BatterySettings) -> Result<()> {
     if !crate::battery_control::BatteryControl::is_available() {
-        log::debug!(target: "hw.battery", "Battery control not available, skipping");
+        log::info!(target: "hw.battery", "Battery control not available, skipping");
         return Ok(());
     }
 
@@ -247,14 +247,14 @@ pub fn apply_battery_settings(settings: &BatterySettings) -> Result<()> {
         battery.set_charge_type("Custom")?;
         battery.set_charge_control_start_threshold(settings.charge_start_threshold)?;
         battery.set_charge_control_end_threshold(settings.charge_end_threshold)?;
-        log::debug!(target: "hw.battery",
+        log::info!(target: "hw.battery",
             "set_thresholds enabled=true start={} end={}",
             settings.charge_start_threshold,
             settings.charge_end_threshold
         );
     } else {
         battery.set_charge_type("Standard")?;
-        log::debug!(target: "hw.battery", "set_thresholds enabled=false mode=\"Standard\"");
+        log::info!(target: "hw.battery", "set_thresholds enabled=false mode=\"Standard\"");
     }
 
     Ok(())
@@ -262,7 +262,7 @@ pub fn apply_battery_settings(settings: &BatterySettings) -> Result<()> {
 
 fn apply_keyboard_settings(settings: &KeyboardSettings) -> Result<()> {
     if !settings.control_enabled {
-        log::debug!(target: "hw.kbd", "keyboard_control enabled=false");
+        log::info!(target: "hw.kbd", "keyboard_control enabled=false");
         if let Ok(kbd) = RgbKeyboardControl::new() {
             let white_mode = KeyboardMode::SingleColor {
                 r: 255,
@@ -277,7 +277,7 @@ fn apply_keyboard_settings(settings: &KeyboardSettings) -> Result<()> {
     
     if let Ok(kbd) = RgbKeyboardControl::new() {
         kbd.set_mode(&settings.mode)?;
-        log::debug!(target: "hw.kbd", "keyboard_settings applied=true");
+        log::info!(target: "hw.kbd", "keyboard_settings applied=true");
         Ok(())
     } else {
         log::warn!(target: "hw.kbd", "Keyboard control not available");
@@ -296,7 +296,7 @@ pub fn preview_keyboard_settings(settings: &KeyboardSettings) -> Result<()> {
 
 fn apply_screen_settings(settings: &ScreenSettings) -> Result<()> {
     if settings.system_control {
-        log::debug!(target: "hw.screen", "Using system screen brightness control");
+        log::info!(target: "hw.screen", "Using system screen brightness control");
         return Ok(());
     }
     
@@ -330,7 +330,7 @@ fn apply_screen_settings(settings: &ScreenSettings) -> Result<()> {
             // Then write to brightness
             match fs::write(&brightness_path, actual_brightness.to_string()) {
                 Ok(_) => {
-                    log::debug!(target: "hw.screen", "set_brightness level={}% path=\"{}\"", settings.brightness, base_path);
+                    log::info!(target: "hw.screen", "set_brightness level={}% path=\"{}\"", settings.brightness, base_path);
                     return Ok(());
                 }
                 Err(e) => {
@@ -354,7 +354,7 @@ pub fn set_tdp_profile(profile_name: &str) -> Result<()> {
     
     if let Some(profile_id) = profiles.iter().position(|p| p == profile_name) {
         io.set_performance_profile(profile_id as u32)?;
-        log::debug!(target: "hw.cpu", "set_tdp_profile name=\"{}\" id={}", profile_name, profile_id);
+        log::info!(target: "hw.cpu", "set_tdp_profile name=\"{}\" id={}", profile_name, profile_id);
         Ok(())
     } else {
         Err(anyhow!("Profile '{}' not found. Available: {:?}", profile_name, profiles))
@@ -367,11 +367,11 @@ pub fn set_fan_speed(fan_id: u32, speed_percent: u32) -> Result<()> {
     }
     
     let speed = speed_percent.min(100);
-    log::debug!(target: "hw.fan", "DBus request: set fan {} to {}%", fan_id, speed);
+    log::info!(target: "hw.fan", "DBus request: set fan {} to {}%", fan_id, speed);
     let io = TuxedoIo::new()?;
     io.set_fan_speed(fan_id, speed)?;
     
-    log::debug!(target: "hw.fan", "set_fan id={} speed={}%", fan_id, speed);
+    log::info!(target: "hw.fan", "set_fan id={} speed={}%", fan_id, speed);
     Ok(())
 }
 
@@ -383,27 +383,27 @@ pub fn set_fan_auto(_fan_id: u32) -> Result<()> {
     let io = TuxedoIo::new()?;
     io.set_fan_auto()?;
     
-    log::debug!(target: "hw.fan", "set_fans_auto");
+    log::info!(target: "hw.fan", "set_fans_auto");
     Ok(())
 }
 
 fn apply_fan_settings(settings: &FanSettings) -> Result<()> {
     if !TuxedoIo::is_available() {
-        log::debug!(target: "hw.fan", "Fan control not available (/dev/tuxedo_io not present)");
+        log::info!(target: "hw.fan", "Fan control not available (/dev/tuxedo_io not present)");
         return Ok(());
     }
     
-    log::debug!(target: "hw.fan", "Applying fan settings: enabled={}", settings.control_enabled);
+    log::info!(target: "hw.fan", "Applying fan settings: enabled={}", settings.control_enabled);
     
     // Update the global fan daemon state
     {
         let mut state = crate::FAN_DAEMON_STATE.lock().unwrap();
         if settings.control_enabled {
             *state = Some(settings.clone());
-            log::debug!(target: "hw.fan", "fan_daemon enabled=true curves={}", settings.curves.len());
+            log::info!(target: "hw.fan", "fan_daemon enabled=true curves={}", settings.curves.len());
         } else {
             *state = None;
-            log::debug!(target: "hw.fan", "fan_daemon enabled=false");
+            log::info!(target: "hw.fan", "fan_daemon enabled=false");
         }
     }
     
@@ -422,7 +422,7 @@ pub fn set_webcam_state(enabled: bool) -> Result<()> {
     let io = TuxedoIo::new()?;
     io.set_webcam_state(enabled)?;
     
-    log::debug!(target: "hw.detect", "set_webcam enabled={}", enabled);
+    log::info!(target: "hw.detect", "set_webcam enabled={}", enabled);
     Ok(())
 }
 
@@ -484,7 +484,7 @@ pub fn set_gpu_core_offset(device_index: u32, offset: f32) -> Result<()> {
         let entry = map.entry(device_index).or_insert((0.0, 0.0));
         entry.0 = offset;
     }
-    log::debug!(target: "hw.gpu", "set_core_offset gpu={} offset={} offset_rounded={}", device_index, offset, offset.round());
+    log::info!(target: "hw.gpu", "set_core_offset gpu={} offset={} offset_rounded={}", device_index, offset, offset.round());
     Ok(())
 }
 
@@ -497,7 +497,7 @@ pub fn set_gpu_memory_offset(device_index: u32, offset: f32) -> Result<()> {
         let entry = map.entry(device_index).or_insert((0.0, 0.0));
         entry.1 = offset;
     }
-    log::debug!(target: "hw.gpu", "set_mem_offset gpu={} offset={} offset_rounded={}", device_index, offset, offset.round());
+    log::info!(target: "hw.gpu", "set_mem_offset gpu={} offset={} offset_rounded={}", device_index, offset, offset.round());
     Ok(())
 }
 
@@ -505,7 +505,7 @@ pub fn set_gpu_power_limit(device_index: u32, limit_watts: u32) -> Result<()> {
     let nvml = get_nvml()?;
     let mut device = nvml.device_by_index(device_index)?;
     device.set_power_management_limit(limit_watts * 1000)?; // Watts to mW
-    log::debug!(target: "hw.gpu", "set_power_limit gpu={} limit={}W", device_index, limit_watts);
+    log::info!(target: "hw.gpu", "set_power_limit gpu={} limit={}W", device_index, limit_watts);
     Ok(())
 }
 
@@ -513,7 +513,7 @@ pub fn set_gpu_fan_speed(device_index: u32, fan_index: u32, speed_percent: u32) 
     let nvml = get_nvml()?;
     let mut device = nvml.device_by_index(device_index)?;
     device.set_fan_speed(fan_index, speed_percent)?;
-    log::debug!(target: "hw.gpu", "set_fan_speed gpu={} fan={} speed={}%", device_index, fan_index, speed_percent);
+    log::info!(target: "hw.gpu", "set_fan_speed gpu={} fan={} speed={}%", device_index, fan_index, speed_percent);
     Ok(())
 }
 
@@ -521,7 +521,7 @@ pub fn set_gpu_fan_auto(device_index: u32, fan_index: u32) -> Result<()> {
     let nvml = get_nvml()?;
     let mut device = nvml.device_by_index(device_index)?;
     device.set_default_fan_speed(fan_index)?;
-    log::debug!(target: "hw.gpu", "set_fan_auto gpu={} fan={}", device_index, fan_index);
+    log::info!(target: "hw.gpu", "set_fan_auto gpu={} fan={}", device_index, fan_index);
     Ok(())
 }
 
@@ -551,7 +551,7 @@ pub fn set_prime_profile(profile: &str) -> Result<()> {
             _ => profile,
         };
 
-        log::debug!(target: "hw.gpu", "set_prime_profile mode=\"{}\" tool=\"optimus-manager\"", opt_mode);
+        log::info!(target: "hw.gpu", "set_prime_profile mode=\"{}\" tool=\"optimus-manager\"", opt_mode);
         let output = std::process::Command::new(path)
             .arg("--switch")
             .arg(opt_mode)
@@ -571,7 +571,7 @@ pub fn set_prime_profile(profile: &str) -> Result<()> {
     if !output.status.success() {
         return Err(anyhow!("prime-select command failed: {}", String::from_utf8_lossy(&output.stderr)));
     }
-    log::debug!(target: "hw.gpu", "set_prime_profile mode=\"{}\" tool=\"prime-select\"", profile);
+    log::info!(target: "hw.gpu", "set_prime_profile mode=\"{}\" tool=\"prime-select\"", profile);
     Ok(())
 }
 
@@ -592,7 +592,7 @@ pub fn set_energy_performance_preference(epp: &str) -> Result<()> {
         }
     }
     
-    log::debug!(target: "hw.cpu", "set_epp preference=\"{}\"", epp);
+    log::info!(target: "hw.cpu", "set_epp preference=\"{}\"", epp);
     Ok(())
 }
 
@@ -682,7 +682,7 @@ impl RgbKeyboardControl {
         let color_str = format!("{} {} {}", red, green, blue);
         fs::write(&color_path, color_str)?;
         
-        log::debug!(target: "hw.kbd", "set_zone_color zone={} r={} g={} b={}", zone_idx, red, green, blue);
+        log::info!(target: "hw.kbd", "set_zone_color zone={} r={} g={} b={}", zone_idx, red, green, blue);
         Ok(())
     }
     
@@ -707,7 +707,7 @@ impl RgbKeyboardControl {
             let _ = fs::write(&brightness_path, actual_brightness.to_string());
         }
         
-        log::debug!(target: "hw.kbd", "set_brightness level={}%", brightness);
+        log::info!(target: "hw.kbd", "set_brightness level={}%", brightness);
         Ok(())
     }
     
@@ -764,7 +764,7 @@ impl RgbKeyboardControl {
                     let _ = self.set_zone_color(i, *r, *g, *b);
                 }
                 self.set_brightness(*brightness)?;
-                log::debug!(target: "hw.kbd", "set_mode mode=\"breathing\" speed={}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"breathing\" speed={}", speed);
             }
             KeyboardMode::Wave { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -775,7 +775,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(7, "wave")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::debug!(target: "hw.kbd", "set_mode mode=\"wave\" speed={}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"wave\" speed={}", speed);
             }
             KeyboardMode::Cycle { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -786,7 +786,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(2, "cycle")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::debug!(target: "hw.kbd", "set_mode mode=\"cycle\" speed={}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"cycle\" speed={}", speed);
             }
             KeyboardMode::Dance { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -797,7 +797,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(3, "dance")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::debug!(target: "hw.kbd", "set_mode mode=\"dance\" speed={}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"dance\" speed={}", speed);
             }
             KeyboardMode::Flash { r, g, b, brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -811,7 +811,7 @@ impl RgbKeyboardControl {
                     let _ = self.set_zone_color(i, *r, *g, *b);
                 }
                 self.set_brightness(*brightness)?;
-                log::debug!(target: "hw.kbd", "set_mode mode=\"flash\" speed={}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"flash\" speed={}", speed);
             }
             KeyboardMode::RandomColor { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -822,7 +822,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(5, "random")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::debug!(target: "hw.kbd", "set_mode mode=\"random\" speed={}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"random\" speed={}", speed);
             }
             KeyboardMode::Tempo { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -833,7 +833,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(6, "tempo")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::debug!(target: "hw.kbd", "set_mode mode=\"tempo\" speed={}", speed);
+                log::info!(target: "hw.kbd", "set_mode mode=\"tempo\" speed={}", speed);
             }
         }
         Ok(())

--- a/daemon/src/hardware_control.rs
+++ b/daemon/src/hardware_control.rs
@@ -27,7 +27,7 @@ pub fn set_cpu_governor(governor: &str) -> Result<()> {
             .map_err(|e| anyhow!("Failed to set governor for CPU {}: {}", i, e))?;
     }
     
-    log::info!(target: "hw.cpu", "set_governor profile=\"{}\"", governor);
+    log::debug!(target: "hw.cpu", "set_governor profile=\"{}\"", governor);
     Ok(())
 }
 
@@ -70,7 +70,7 @@ pub fn set_cpu_frequency_limits(min_freq: u64, max_freq: u64) -> Result<()> {
     }
     
     CPU_LIMITS_MODIFIED.store(true, Ordering::SeqCst);
-    log::info!(target: "hw.cpu", "set_freq_limits min={} max={}", min_freq, max_freq);
+    log::debug!(target: "hw.cpu", "set_freq_limits min={} max={}", min_freq, max_freq);
     Ok(())
 }
 
@@ -94,7 +94,7 @@ pub fn set_cpu_boost(enabled: bool) -> Result<()> {
     let amd_path = "/sys/devices/system/cpu/cpufreq/boost";
     if Path::new(amd_path).exists() {
         fs::write(amd_path, if enabled { "1" } else { "0" })?;
-        log::info!(target: "hw.cpu", "set_amd_boost enabled={}", enabled);
+        log::debug!(target: "hw.cpu", "set_amd_boost enabled={}", enabled);
         return Ok(());
     }
     
@@ -102,7 +102,7 @@ pub fn set_cpu_boost(enabled: bool) -> Result<()> {
     let intel_path = "/sys/devices/system/cpu/intel_pstate/no_turbo";
     if Path::new(intel_path).exists() {
         fs::write(intel_path, if enabled { "0" } else { "1" })?;
-        log::info!(target: "hw.cpu", "set_intel_turbo enabled={}", enabled);
+        log::debug!(target: "hw.cpu", "set_intel_turbo enabled={}", enabled);
         return Ok(());
     }
     
@@ -110,7 +110,7 @@ pub fn set_cpu_boost(enabled: bool) -> Result<()> {
     let amd_pstate_boost = "/sys/devices/system/cpu/amd_pstate/cpb_boost";
     if Path::new(amd_pstate_boost).exists() {
         fs::write(amd_pstate_boost, if enabled { "1" } else { "0" })?;
-        log::info!(target: "hw.cpu", "set_amd_pstate_boost enabled={}", enabled);
+        log::debug!(target: "hw.cpu", "set_amd_pstate_boost enabled={}", enabled);
         return Ok(());
     }
     
@@ -124,7 +124,7 @@ pub fn set_smt(enabled: bool) -> Result<()> {
     }
     
     fs::write(path, if enabled { "on" } else { "off" })?;
-    log::info!(target: "hw.cpu", "set_smt enabled={}", enabled);
+    log::debug!(target: "hw.cpu", "set_smt enabled={}", enabled);
     Ok(())
 }
 
@@ -139,7 +139,7 @@ pub fn set_amd_pstate_status(status: &str) -> Result<()> {
     }
     
     fs::write(path, status)?;
-    log::info!(target: "hw.cpu", "set_amd_pstate_status status=\"{}\"", status);
+    log::debug!(target: "hw.cpu", "set_amd_pstate_status status=\"{}\"", status);
     Ok(())
 }
 
@@ -154,7 +154,7 @@ pub fn set_intel_pstate_status(status: &str) -> Result<()> {
     }
 
     fs::write(path, status)?;
-    log::info!(target: "hw.cpu", "set_intel_pstate_status status=\"{}\"", status);
+    log::debug!(target: "hw.cpu", "set_intel_pstate_status status=\"{}\"", status);
     Ok(())
 }
 
@@ -247,14 +247,14 @@ pub fn apply_battery_settings(settings: &BatterySettings) -> Result<()> {
         battery.set_charge_type("Custom")?;
         battery.set_charge_control_start_threshold(settings.charge_start_threshold)?;
         battery.set_charge_control_end_threshold(settings.charge_end_threshold)?;
-        log::info!(target: "hw.battery",
+        log::debug!(target: "hw.battery",
             "set_thresholds enabled=true start={} end={}",
             settings.charge_start_threshold,
             settings.charge_end_threshold
         );
     } else {
         battery.set_charge_type("Standard")?;
-        log::info!(target: "hw.battery", "set_thresholds enabled=false mode=\"Standard\"");
+        log::debug!(target: "hw.battery", "set_thresholds enabled=false mode=\"Standard\"");
     }
 
     Ok(())
@@ -262,7 +262,7 @@ pub fn apply_battery_settings(settings: &BatterySettings) -> Result<()> {
 
 fn apply_keyboard_settings(settings: &KeyboardSettings) -> Result<()> {
     if !settings.control_enabled {
-        log::info!(target: "hw.kbd", "keyboard_control enabled=false");
+        log::debug!(target: "hw.kbd", "keyboard_control enabled=false");
         if let Ok(kbd) = RgbKeyboardControl::new() {
             let white_mode = KeyboardMode::SingleColor {
                 r: 255,
@@ -277,7 +277,7 @@ fn apply_keyboard_settings(settings: &KeyboardSettings) -> Result<()> {
     
     if let Ok(kbd) = RgbKeyboardControl::new() {
         kbd.set_mode(&settings.mode)?;
-        log::info!(target: "hw.kbd", "keyboard_settings applied=true");
+        log::debug!(target: "hw.kbd", "keyboard_settings applied=true");
         Ok(())
     } else {
         log::warn!(target: "hw.kbd", "Keyboard control not available");
@@ -330,7 +330,7 @@ fn apply_screen_settings(settings: &ScreenSettings) -> Result<()> {
             // Then write to brightness
             match fs::write(&brightness_path, actual_brightness.to_string()) {
                 Ok(_) => {
-                    log::info!(target: "hw.screen", "set_brightness level={}% path=\"{}\"", settings.brightness, base_path);
+                    log::debug!(target: "hw.screen", "set_brightness level={}% path=\"{}\"", settings.brightness, base_path);
                     return Ok(());
                 }
                 Err(e) => {
@@ -354,7 +354,7 @@ pub fn set_tdp_profile(profile_name: &str) -> Result<()> {
     
     if let Some(profile_id) = profiles.iter().position(|p| p == profile_name) {
         io.set_performance_profile(profile_id as u32)?;
-        log::info!(target: "hw.cpu", "set_tdp_profile name=\"{}\" id={}", profile_name, profile_id);
+        log::debug!(target: "hw.cpu", "set_tdp_profile name=\"{}\" id={}", profile_name, profile_id);
         Ok(())
     } else {
         Err(anyhow!("Profile '{}' not found. Available: {:?}", profile_name, profiles))
@@ -371,7 +371,7 @@ pub fn set_fan_speed(fan_id: u32, speed_percent: u32) -> Result<()> {
     let io = TuxedoIo::new()?;
     io.set_fan_speed(fan_id, speed)?;
     
-    log::info!(target: "hw.fan", "set_fan id={} speed={}%", fan_id, speed);
+    log::debug!(target: "hw.fan", "set_fan id={} speed={}%", fan_id, speed);
     Ok(())
 }
 
@@ -383,7 +383,7 @@ pub fn set_fan_auto(_fan_id: u32) -> Result<()> {
     let io = TuxedoIo::new()?;
     io.set_fan_auto()?;
     
-    log::info!(target: "hw.fan", "set_fans_auto");
+    log::debug!(target: "hw.fan", "set_fans_auto");
     Ok(())
 }
 
@@ -400,10 +400,10 @@ fn apply_fan_settings(settings: &FanSettings) -> Result<()> {
         let mut state = crate::FAN_DAEMON_STATE.lock().unwrap();
         if settings.control_enabled {
             *state = Some(settings.clone());
-            log::info!(target: "hw.fan", "fan_daemon enabled=true curves={}", settings.curves.len());
+            log::debug!(target: "hw.fan", "fan_daemon enabled=true curves={}", settings.curves.len());
         } else {
             *state = None;
-            log::info!(target: "hw.fan", "fan_daemon enabled=false");
+            log::debug!(target: "hw.fan", "fan_daemon enabled=false");
         }
     }
     
@@ -422,7 +422,7 @@ pub fn set_webcam_state(enabled: bool) -> Result<()> {
     let io = TuxedoIo::new()?;
     io.set_webcam_state(enabled)?;
     
-    log::info!(target: "hw.detect", "set_webcam enabled={}", enabled);
+    log::debug!(target: "hw.detect", "set_webcam enabled={}", enabled);
     Ok(())
 }
 
@@ -484,7 +484,7 @@ pub fn set_gpu_core_offset(device_index: u32, offset: f32) -> Result<()> {
         let entry = map.entry(device_index).or_insert((0.0, 0.0));
         entry.0 = offset;
     }
-    log::info!(target: "hw.gpu", "set_core_offset gpu={} offset={} offset_rounded={}", device_index, offset, offset.round());
+    log::debug!(target: "hw.gpu", "set_core_offset gpu={} offset={} offset_rounded={}", device_index, offset, offset.round());
     Ok(())
 }
 
@@ -497,7 +497,7 @@ pub fn set_gpu_memory_offset(device_index: u32, offset: f32) -> Result<()> {
         let entry = map.entry(device_index).or_insert((0.0, 0.0));
         entry.1 = offset;
     }
-    log::info!(target: "hw.gpu", "set_mem_offset gpu={} offset={} offset_rounded={}", device_index, offset, offset.round());
+    log::debug!(target: "hw.gpu", "set_mem_offset gpu={} offset={} offset_rounded={}", device_index, offset, offset.round());
     Ok(())
 }
 
@@ -505,7 +505,7 @@ pub fn set_gpu_power_limit(device_index: u32, limit_watts: u32) -> Result<()> {
     let nvml = get_nvml()?;
     let mut device = nvml.device_by_index(device_index)?;
     device.set_power_management_limit(limit_watts * 1000)?; // Watts to mW
-    log::info!(target: "hw.gpu", "set_power_limit gpu={} limit={}W", device_index, limit_watts);
+    log::debug!(target: "hw.gpu", "set_power_limit gpu={} limit={}W", device_index, limit_watts);
     Ok(())
 }
 
@@ -513,7 +513,7 @@ pub fn set_gpu_fan_speed(device_index: u32, fan_index: u32, speed_percent: u32) 
     let nvml = get_nvml()?;
     let mut device = nvml.device_by_index(device_index)?;
     device.set_fan_speed(fan_index, speed_percent)?;
-    log::info!(target: "hw.gpu", "set_fan_speed gpu={} fan={} speed={}%", device_index, fan_index, speed_percent);
+    log::debug!(target: "hw.gpu", "set_fan_speed gpu={} fan={} speed={}%", device_index, fan_index, speed_percent);
     Ok(())
 }
 
@@ -521,7 +521,7 @@ pub fn set_gpu_fan_auto(device_index: u32, fan_index: u32) -> Result<()> {
     let nvml = get_nvml()?;
     let mut device = nvml.device_by_index(device_index)?;
     device.set_default_fan_speed(fan_index)?;
-    log::info!(target: "hw.gpu", "set_fan_auto gpu={} fan={}", device_index, fan_index);
+    log::debug!(target: "hw.gpu", "set_fan_auto gpu={} fan={}", device_index, fan_index);
     Ok(())
 }
 
@@ -551,7 +551,7 @@ pub fn set_prime_profile(profile: &str) -> Result<()> {
             _ => profile,
         };
 
-        log::info!(target: "hw.gpu", "set_prime_profile mode=\"{}\" tool=\"optimus-manager\"", opt_mode);
+        log::debug!(target: "hw.gpu", "set_prime_profile mode=\"{}\" tool=\"optimus-manager\"", opt_mode);
         let output = std::process::Command::new(path)
             .arg("--switch")
             .arg(opt_mode)
@@ -571,7 +571,7 @@ pub fn set_prime_profile(profile: &str) -> Result<()> {
     if !output.status.success() {
         return Err(anyhow!("prime-select command failed: {}", String::from_utf8_lossy(&output.stderr)));
     }
-    log::info!(target: "hw.gpu", "set_prime_profile mode=\"{}\" tool=\"prime-select\"", profile);
+    log::debug!(target: "hw.gpu", "set_prime_profile mode=\"{}\" tool=\"prime-select\"", profile);
     Ok(())
 }
 
@@ -592,7 +592,7 @@ pub fn set_energy_performance_preference(epp: &str) -> Result<()> {
         }
     }
     
-    log::info!(target: "hw.cpu", "set_epp preference=\"{}\"", epp);
+    log::debug!(target: "hw.cpu", "set_epp preference=\"{}\"", epp);
     Ok(())
 }
 
@@ -682,7 +682,7 @@ impl RgbKeyboardControl {
         let color_str = format!("{} {} {}", red, green, blue);
         fs::write(&color_path, color_str)?;
         
-        log::info!(target: "hw.kbd", "set_zone_color zone={} r={} g={} b={}", zone_idx, red, green, blue);
+        log::debug!(target: "hw.kbd", "set_zone_color zone={} r={} g={} b={}", zone_idx, red, green, blue);
         Ok(())
     }
     
@@ -707,7 +707,7 @@ impl RgbKeyboardControl {
             let _ = fs::write(&brightness_path, actual_brightness.to_string());
         }
         
-        log::info!(target: "hw.kbd", "set_brightness level={}%", brightness);
+        log::debug!(target: "hw.kbd", "set_brightness level={}%", brightness);
         Ok(())
     }
     
@@ -764,7 +764,7 @@ impl RgbKeyboardControl {
                     let _ = self.set_zone_color(i, *r, *g, *b);
                 }
                 self.set_brightness(*brightness)?;
-                log::info!(target: "hw.kbd", "set_mode mode=\"breathing\" speed={}", speed);
+                log::debug!(target: "hw.kbd", "set_mode mode=\"breathing\" speed={}", speed);
             }
             KeyboardMode::Wave { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -775,7 +775,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(7, "wave")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::info!(target: "hw.kbd", "set_mode mode=\"wave\" speed={}", speed);
+                log::debug!(target: "hw.kbd", "set_mode mode=\"wave\" speed={}", speed);
             }
             KeyboardMode::Cycle { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -786,7 +786,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(2, "cycle")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::info!(target: "hw.kbd", "set_mode mode=\"cycle\" speed={}", speed);
+                log::debug!(target: "hw.kbd", "set_mode mode=\"cycle\" speed={}", speed);
             }
             KeyboardMode::Dance { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -797,7 +797,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(3, "dance")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::info!(target: "hw.kbd", "set_mode mode=\"dance\" speed={}", speed);
+                log::debug!(target: "hw.kbd", "set_mode mode=\"dance\" speed={}", speed);
             }
             KeyboardMode::Flash { r, g, b, brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -811,7 +811,7 @@ impl RgbKeyboardControl {
                     let _ = self.set_zone_color(i, *r, *g, *b);
                 }
                 self.set_brightness(*brightness)?;
-                log::info!(target: "hw.kbd", "set_mode mode=\"flash\" speed={}", speed);
+                log::debug!(target: "hw.kbd", "set_mode mode=\"flash\" speed={}", speed);
             }
             KeyboardMode::RandomColor { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -822,7 +822,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(5, "random")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::info!(target: "hw.kbd", "set_mode mode=\"random\" speed={}", speed);
+                log::debug!(target: "hw.kbd", "set_mode mode=\"random\" speed={}", speed);
             }
             KeyboardMode::Tempo { brightness, speed } => {
                 if let Some(ref io) = self.tuxedo_io {
@@ -833,7 +833,7 @@ impl RgbKeyboardControl {
                 self.write_effect_mode(6, "tempo")?;
                 self.write_effect_speed(*speed)?;
                 self.set_brightness(*brightness)?;
-                log::info!(target: "hw.kbd", "set_mode mode=\"tempo\" speed={}", speed);
+                log::debug!(target: "hw.kbd", "set_mode mode=\"tempo\" speed={}", speed);
             }
         }
         Ok(())

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -3214,6 +3214,19 @@ fn read_wifi_rates(interface: &str, tx_bytes: u64, rx_bytes: u64) -> (Option<f64
     rates
 }
 
+fn normalize_uid(uid: String) -> String {
+    let trimmed = uid.trim();
+    // Check if it looks like a MAC address (6 pairs of hex digits separated by colons or dashes, or just 12 hex digits)
+    let is_mac = (trimmed.len() == 17 && (trimmed.contains(':') || trimmed.contains('-'))) ||
+                 (trimmed.len() == 12 && trimmed.chars().all(|c| c.is_ascii_hexdigit()));
+
+    if is_mac {
+        trimmed.replace(':', "").replace('-', "").to_lowercase()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 pub fn get_gamepad_info() -> Result<Vec<GamepadInfo>> {
     let mut gamepads = Vec::new();
     let mut seen_uids = std::collections::HashSet::new();
@@ -3263,7 +3276,7 @@ pub fn get_gamepad_info() -> Result<Vec<GamepadInfo>> {
                                             }
                                         }
                                         // Priority: Serial Short > Serial > Path
-                                        udev_uid = id_serial_short.or(id_serial).or(id_path);
+                        udev_uid = id_serial_short.or(id_serial).or(id_path).map(normalize_uid);
 
                                         if is_gamepad {
                                             break;
@@ -3311,7 +3324,7 @@ pub fn get_gamepad_info() -> Result<Vec<GamepadInfo>> {
                         if let Ok(uniq) = fs::read_to_string(path.join("device/uniq")) {
                             let uniq = uniq.trim();
                             if !uniq.is_empty() && uniq != "00:00:00:00:00:00" {
-                                uid = uniq.to_string();
+                                uid = normalize_uid(uniq.to_string());
                             }
                         }
 

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -35,6 +35,8 @@ struct NvidiaMetadata {
     vram_total: Option<u64>,
     core_clock_range: Option<(u32, u32)>,
     memory_clock_range: Option<(u32, u32)>,
+    core_offset_limits: Option<(i32, i32)>,
+    memory_offset_limits: Option<(i32, i32)>,
 }
 
 static NVIDIA_METADATA_CACHE: Lazy<Mutex<HashMap<u32, NvidiaMetadata>>> =
@@ -669,7 +671,7 @@ pub fn get_tdp_profiles() -> Result<Vec<String>> {
                     static LOGGED_ONCE: Mutex<bool> = Mutex::new(false);
                     let mut logged = LOGGED_ONCE.lock().unwrap();
                     if !*logged {
-                        log::info!(target: "hw.detect", "Available TDP profiles: {:?}", profiles);
+                        log::debug!(target: "hw.detect", "Available TDP profiles: {:?}", profiles);
                         *logged = true;
                     }
                     Ok(profiles)
@@ -685,6 +687,34 @@ pub fn get_tdp_profiles() -> Result<Vec<String>> {
             Ok(vec![])
         }
     }
+}
+
+/// Internal helper to get base memory clock ranges across all performance states
+fn get_base_memory_clock_ranges(device: &nvml_wrapper::Device) -> Result<(u32, u32)> {
+    let mut range = None;
+    if let Ok(supported_states) = device.supported_performance_states() {
+        let mut m_min = u32::MAX;
+        let mut m_max = 0;
+        for pstate in supported_states {
+            if let Ok((p_min, p_max)) = device.min_max_clock_of_pstate(Clock::Memory, pstate) {
+                if p_min < m_min { m_min = p_min; }
+                if p_max > m_max { m_max = p_max; }
+            }
+        }
+        if m_min != u32::MAX {
+            range = Some((m_min, m_max));
+        }
+    }
+
+    if range.is_none() {
+        if let Ok(clocks) = device.supported_memory_clocks() {
+            if let (Some(&c_min), Some(&c_max)) = (clocks.iter().min(), clocks.iter().max()) {
+                range = Some((c_min, c_max));
+            }
+        }
+    }
+
+    range.ok_or_else(|| anyhow!("Could not determine memory clock ranges"))
 }
 
 pub fn get_current_tdp_profile() -> Result<String> {
@@ -1431,10 +1461,19 @@ fn get_base_gpu_clock_ranges(device: &nvml_wrapper::Device) -> Result<(u32, u32)
 }
 
 pub fn get_gpu_clock_ranges(device_index: u32) -> Result<(u32, u32)> {
-    let nvml = get_nvml()?;
-    let device = nvml.device_by_index(device_index)?;
+    // Try cache first to avoid waking up GPU
+    let cached_range = {
+        let cache = NVIDIA_METADATA_CACHE.lock().unwrap();
+        cache.get(&device_index).and_then(|m| m.core_clock_range)
+    };
 
-    let (mut min, mut max) = get_base_gpu_clock_ranges(&device)?;
+    let (mut min, mut max) = if let Some(range) = cached_range {
+        range
+    } else {
+        let nvml = get_nvml()?;
+        let device = nvml.device_by_index(device_index)?;
+        get_base_gpu_clock_ranges(&device)?
+    };
 
     // Add current core offset if any to show real-time effective ranges in the UI
     let offset = {
@@ -1450,6 +1489,16 @@ pub fn get_gpu_clock_ranges(device_index: u32) -> Result<(u32, u32)> {
 
 
 pub fn get_gpu_core_offset_limits(device_index: u32) -> Result<(i32, i32)> {
+    // Try cache first
+    let cached_limits = {
+        let cache = NVIDIA_METADATA_CACHE.lock().unwrap();
+        cache.get(&device_index).and_then(|m| m.core_offset_limits)
+    };
+
+    if let Some(limits) = cached_limits {
+        return Ok(limits);
+    }
+
     let nvml = get_nvml()?;
     let device = nvml.device_by_index(device_index)?;
     let offset_info = device.clock_offset(Clock::Graphics, PerformanceState::Zero)?;
@@ -1457,6 +1506,16 @@ pub fn get_gpu_core_offset_limits(device_index: u32) -> Result<(i32, i32)> {
 }
 
 pub fn get_gpu_memory_offset_limits(device_index: u32) -> Result<(i32, i32)> {
+    // Try cache first
+    let cached_limits = {
+        let cache = NVIDIA_METADATA_CACHE.lock().unwrap();
+        cache.get(&device_index).and_then(|m| m.memory_offset_limits)
+    };
+
+    if let Some(limits) = cached_limits {
+        return Ok(limits);
+    }
+
     let nvml = get_nvml()?;
     let device = nvml.device_by_index(device_index)?;
     let offset_info = device.clock_offset(Clock::Memory, PerformanceState::Zero)?;
@@ -1811,7 +1870,7 @@ fn get_vram_info(minor_number: u32) -> (Option<String>, Option<String>, Option<u
             
             // Log summary of detection results
             if ram_type_val.is_some() || bus_width.is_some() || vendor_id.is_some() {
-                log::info!(target: "hw.detect", "Successfully retrieved partial VRAM info for minor {}: type={}, bus={}, vendor={}", 
+                log::debug!(target: "hw.detect", "Successfully retrieved partial VRAM info for minor {}: type={}, bus={}, vendor={}",
                     minor_number, 
                     ram_type_val.map(|v| format!("0x{:08x}", v)).unwrap_or_else(|| "None".to_string()),
                     bus_width.map(|v| format!("{} bits", v)).unwrap_or_else(|| "None".to_string()),
@@ -2334,32 +2393,62 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             let mut cache = NVIDIA_METADATA_CACHE.lock().unwrap();
             if let Some(meta) = cache.get(&i) {
                 log::debug!(target: "hw.detect", "GPU {}: Using cached metadata", i);
-                // Check if cached VRAM info is None - if so, retry getting it
+                // Check if cached metadata is incomplete - if so, retry getting it
                 // This handles cases where initial detection failed (GPU suspended, driver not ready, etc.)
-                if meta.vram_type.is_none() && meta.vram_vendor.is_none() && meta.vram_bus_width.is_none() {
-                    log::info!(target: "hw.detect", "GPU {}: Cached VRAM info is all None, retrying detection", i);
+                let incomplete_vram = meta.vram_type.is_none() && meta.vram_vendor.is_none() && meta.vram_bus_width.is_none();
+                let incomplete_ranges = meta.core_clock_range.is_none() || meta.memory_clock_range.is_none();
+                let incomplete_offsets = meta.core_offset_limits.is_none() || meta.memory_offset_limits.is_none();
+
+                if incomplete_vram || incomplete_ranges || incomplete_offsets {
+                    log::info!(target: "hw.detect", "GPU {}: Cached metadata is incomplete, retrying detection", i);
                     let minor_number = device.minor_number().unwrap_or(i);
-                    let (vram_type, vram_vendor, vram_bus_width, _) = get_vram_info(minor_number);
                     
-                    // If we successfully got VRAM info, update the cache
-                    if vram_type.is_some() || vram_vendor.is_some() || vram_bus_width.is_some() {
-                        log::info!(target: "hw.detect", "GPU {}: Successfully detected VRAM on retry - Type: {:?}, Vendor: {:?}, Bus: {:?}",
-                            i, vram_type, vram_vendor, vram_bus_width);
-                        let updated_meta = NvidiaMetadata {
-                            vram_type,
-                            vram_vendor,
-                            vram_bus_width,
-                            ..meta.clone()
-                        };
-                        cache.insert(i, updated_meta.clone());
-                        updated_meta
+                    let (vram_type, vram_vendor, vram_bus_width, _) = if incomplete_vram {
+                        get_vram_info(minor_number)
                     } else {
-                        log::warn!(target: "hw.detect", "GPU {}: VRAM detection retry also returned None - see errors above for details", i);
-                        meta.clone()
-                    }
+                        (meta.vram_type.clone(), meta.vram_vendor.clone(), meta.vram_bus_width, None)
+                    };
+
+                    let core_range = if meta.core_clock_range.is_none() {
+                        get_base_gpu_clock_ranges(&device).ok()
+                    } else {
+                        meta.core_clock_range
+                    };
+
+                    let mem_range = if meta.memory_clock_range.is_none() {
+                        get_base_memory_clock_ranges(&device).ok()
+                    } else {
+                        meta.memory_clock_range
+                    };
+
+                    let core_offset_limits = if meta.core_offset_limits.is_none() {
+                        device.clock_offset(Clock::Graphics, PerformanceState::Zero).ok()
+                            .map(|o| (o.min_clock_offset_mhz, o.max_clock_offset_mhz))
+                    } else {
+                        meta.core_offset_limits
+                    };
+
+                    let memory_offset_limits = if meta.memory_offset_limits.is_none() {
+                        device.clock_offset(Clock::Memory, PerformanceState::Zero).ok()
+                            .map(|o| (o.min_clock_offset_mhz, o.max_clock_offset_mhz))
+                    } else {
+                        meta.memory_offset_limits
+                    };
+
+                    let updated_meta = NvidiaMetadata {
+                        vram_type,
+                        vram_vendor,
+                        vram_bus_width,
+                        core_clock_range: core_range,
+                        memory_clock_range: mem_range,
+                        core_offset_limits,
+                        memory_offset_limits,
+                        ..meta.clone()
+                    };
+                    cache.insert(i, updated_meta.clone());
+                    updated_meta
                 } else {
-                    log::debug!(target: "hw.detect", "GPU {}: Using cached VRAM info - Type: {:?}, Vendor: {:?}, Bus: {:?}", 
-                        i, meta.vram_type, meta.vram_vendor, meta.vram_bus_width);
+                    log::debug!(target: "hw.detect", "GPU {}: Using cached metadata", i);
                     meta.clone()
                 }
             } else {
@@ -2382,30 +2471,13 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 let (vram_type, vram_vendor, vram_bus_width, _) = get_vram_info(minor_number);
 
                 let core_range = get_base_gpu_clock_ranges(&device).ok();
+                let mem_range = get_base_memory_clock_ranges(&device).ok();
 
-                let mut mem_range = None;
-                if let Ok(supported_states) = device.supported_performance_states() {
-                    let mut m_min = u32::MAX;
-                    let mut m_max = 0;
-                    for pstate in supported_states {
-                        if let Ok((p_min, p_max)) = device.min_max_clock_of_pstate(Clock::Memory, pstate) {
-                            if p_min < m_min { m_min = p_min; }
-                            if p_max > m_max { m_max = p_max; }
-                        }
-                    }
-                    if m_min != u32::MAX {
-                        mem_range = Some((m_min, m_max));
-                    }
-                }
 
-                // Fallback for memory clock range
-                if mem_range.is_none() {
-                    if let Ok(clocks) = device.supported_memory_clocks() {
-                        if let (Some(&c_min), Some(&c_max)) = (clocks.iter().min(), clocks.iter().max()) {
-                            mem_range = Some((c_min, c_max));
-                        }
-                    }
-                }
+                let core_offset_limits = device.clock_offset(Clock::Graphics, PerformanceState::Zero).ok()
+                    .map(|o| (o.min_clock_offset_mhz, o.max_clock_offset_mhz));
+                let memory_offset_limits = device.clock_offset(Clock::Memory, PerformanceState::Zero).ok()
+                    .map(|o| (o.min_clock_offset_mhz, o.max_clock_offset_mhz));
 
                 let meta = NvidiaMetadata {
                     architecture: arch,
@@ -2419,6 +2491,8 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                     vram_total,
                     core_clock_range: core_range,
                     memory_clock_range: mem_range,
+                    core_offset_limits,
+                    memory_offset_limits,
                 };
                 cache.insert(i, meta.clone());
                 meta
@@ -2462,11 +2536,11 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
         if should_log_vram {
             if v_type.is_some() || v_vendor.is_some() || v_bus.is_some() {
                 if v_bw.is_none() && memory_clock_range.is_none() {
-                    log::info!(target: "hw.detect",
+                    log::debug!(target: "hw.detect",
                         "GPU {}: VRAM detected - Type: {:?}, Vendor: {:?}, Bus Width: {:?} bits, Bandwidth: N/A (memory clock range unknown)",
                         i, v_type, v_vendor, v_bus);
                 } else {
-                    log::info!(target: "hw.detect",
+                    log::debug!(target: "hw.detect",
                         "GPU {}: VRAM detected - Type: {:?}, Vendor: {:?}, Bus Width: {:?} bits, Bandwidth: {:?} GB/s",
                         i, v_type, v_vendor, v_bus, v_bw);
                 }

--- a/daemon/src/hardware_detection.rs
+++ b/daemon/src/hardware_detection.rs
@@ -1370,6 +1370,8 @@ pub fn get_gpu_info() -> Result<Vec<GpuInfo>> {
                 max_memory_clock: None,
                 core_clock_range: None,
                 memory_clock_range: None,
+                core_offset_limits: None,
+                memory_offset_limits: None,
                 is_desktop: false,
                 architecture: None,
                 nvml_index: None,
@@ -1470,6 +1472,10 @@ pub fn get_gpu_clock_ranges(device_index: u32) -> Result<(u32, u32)> {
     let (mut min, mut max) = if let Some(range) = cached_range {
         range
     } else {
+        // If not in cache, check if GPU is suspended before waking it up
+        if is_gpu_suspended_by_index(device_index) {
+            return Err(anyhow!("GPU suspended and metadata not cached"));
+        }
         let nvml = get_nvml()?;
         let device = nvml.device_by_index(device_index)?;
         get_base_gpu_clock_ranges(&device)?
@@ -1499,6 +1505,10 @@ pub fn get_gpu_core_offset_limits(device_index: u32) -> Result<(i32, i32)> {
         return Ok(limits);
     }
 
+    if is_gpu_suspended_by_index(device_index) {
+        return Err(anyhow!("GPU suspended and metadata not cached"));
+    }
+
     let nvml = get_nvml()?;
     let device = nvml.device_by_index(device_index)?;
     let offset_info = device.clock_offset(Clock::Graphics, PerformanceState::Zero)?;
@@ -1516,10 +1526,35 @@ pub fn get_gpu_memory_offset_limits(device_index: u32) -> Result<(i32, i32)> {
         return Ok(limits);
     }
 
+    if is_gpu_suspended_by_index(device_index) {
+        return Err(anyhow!("GPU suspended and metadata not cached"));
+    }
+
     let nvml = get_nvml()?;
     let device = nvml.device_by_index(device_index)?;
     let offset_info = device.clock_offset(Clock::Memory, PerformanceState::Zero)?;
     Ok((offset_info.min_clock_offset_mhz, offset_info.max_clock_offset_mhz))
+}
+
+fn is_gpu_suspended_by_index(index: u32) -> bool {
+    let mut nvidia_pci_ids = Vec::new();
+    if let Ok(entries) = fs::read_dir("/sys/bus/pci/drivers/nvidia") {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.contains(':') {
+                nvidia_pci_ids.push(name);
+            }
+        }
+    }
+    nvidia_pci_ids.sort();
+
+    if let Some(id) = nvidia_pci_ids.get(index as usize) {
+        let status_path = format!("/sys/bus/pci/drivers/nvidia/{}/power/runtime_status", id);
+        if let Ok(status) = fs::read_to_string(status_path) {
+            return status.trim().eq_ignore_ascii_case("suspended");
+        }
+    }
+    false
 }
 
 // NVIDIA Direct Driver Constants and Structs
@@ -2170,6 +2205,8 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 max_memory_clock: None,
                 core_clock_range: cached_metadata.as_ref().and_then(|m| m.core_clock_range),
                 memory_clock_range: cached_metadata.as_ref().and_then(|m| m.memory_clock_range),
+                core_offset_limits: cached_metadata.as_ref().and_then(|m| m.core_offset_limits),
+                memory_offset_limits: cached_metadata.as_ref().and_then(|m| m.memory_offset_limits),
                 is_desktop: false,
                 architecture: cached_metadata.as_ref().and_then(|m| m.architecture.clone()),
                 nvml_index: Some(i as u32),
@@ -2251,6 +2288,8 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 max_memory_clock: None,
                 core_clock_range: cached_metadata.as_ref().and_then(|m| m.core_clock_range),
                 memory_clock_range: cached_metadata.as_ref().and_then(|m| m.memory_clock_range),
+                core_offset_limits: cached_metadata.as_ref().and_then(|m| m.core_offset_limits),
+                memory_offset_limits: cached_metadata.as_ref().and_then(|m| m.memory_offset_limits),
                 is_desktop: false,
                 architecture: cached_metadata.as_ref().and_then(|m| m.architecture.clone()),
                 nvml_index: Some(i),
@@ -2400,7 +2439,7 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
                 let incomplete_offsets = meta.core_offset_limits.is_none() || meta.memory_offset_limits.is_none();
 
                 if incomplete_vram || incomplete_ranges || incomplete_offsets {
-                    log::info!(target: "hw.detect", "GPU {}: Cached metadata is incomplete, retrying detection", i);
+                    log::debug!(target: "hw.detect", "GPU {}: Cached metadata is incomplete, retrying detection", i);
                     let minor_number = device.minor_number().unwrap_or(i);
                     
                     let (vram_type, vram_vendor, vram_bus_width, _) = if incomplete_vram {
@@ -2518,6 +2557,8 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             ((min as f32 + offset).max(0.0) as u32, (max as f32 + offset).max(0.0) as u32)
         });
         let memory_clock_range = metadata.memory_clock_range;
+        let core_offset_limits = metadata.core_offset_limits;
+        let memory_offset_limits = metadata.memory_offset_limits;
         let v_bw = calculate_vram_bandwidth(v_type.as_ref(), v_bus, memory_clock_range);
 
         // Log VRAM info for diagnostics (rate-limited)
@@ -2573,6 +2614,8 @@ fn get_nvidia_gpu_info() -> Result<Vec<GpuInfo>> {
             max_memory_clock: None,
             core_clock_range,
             memory_clock_range,
+            core_offset_limits,
+            memory_offset_limits,
             is_desktop,
             architecture,
             nvml_index: Some(i),

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -222,8 +222,8 @@ async fn main() -> Result<()> {
                     tuxedo_io::HardwareInterface::Uniwill => "Uniwill",
                     tuxedo_io::HardwareInterface::None => "None",
                 };
-                log::info!("Detected hardware interface: {}", interface);
-                log::info!("Number of fans: {}", io.get_fan_count());
+                log::debug!("Detected hardware interface: {}", interface);
+                log::debug!("Number of fans: {}", io.get_fan_count());
                 Some(io)
             }
             Err(e) => {
@@ -232,15 +232,15 @@ async fn main() -> Result<()> {
             }
         }
     } else {
-        log::warn!("/dev/tuxedo_io not available - some features will be disabled");
+        log::debug!("/dev/tuxedo_io not available - some features will be disabled");
         None
     };
 
     // Check battery charge control
     if battery_control::BatteryControl::is_available() {
-        log::info!("Battery charge control (flexicharger) is available");
+        log::debug!("Battery charge control (flexicharger) is available");
     } else {
-        log::info!("Battery charge control not available");
+        log::debug!("Battery charge control not available");
     }
 
     // Create and start polling scheduler
@@ -251,9 +251,9 @@ async fn main() -> Result<()> {
     SCHEDULER_HANDLE.set(scheduler_handle.clone()).ok();
     
     // Initial hardware poll to populate cache immediately
-    log::info!("Performing initial hardware detection...");
+    log::debug!("Performing initial hardware detection...");
     refresh_hardware_cache();
-    log::info!("Initial hardware detection complete");
+    log::debug!("Initial hardware detection complete");
 
     // Start scheduler in background
     tokio::spawn(async move {
@@ -275,7 +275,7 @@ async fn main() -> Result<()> {
     if let Err(e) = scheduler_handle.add_job(hw_monitor_job) {
         log::error!("Failed to add hardware monitor job: {}", e);
     } else {
-        log::info!("Hardware monitor polling job added");
+        log::debug!("Hardware monitor polling job added");
     }
 
     // Add fan control polling job if hardware is available
@@ -314,7 +314,7 @@ async fn main() -> Result<()> {
         if let Err(e) = scheduler_handle.add_job(fan_job) {
             log::error!("Failed to add fan control job: {}", e);
         } else {
-            log::info!("Fan control polling job added");
+            log::debug!("Fan control polling job added");
         }
     }
 
@@ -346,7 +346,7 @@ async fn main() -> Result<()> {
         move || {
             let tick = log_tick.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
             if tick % 60 == 0 {
-                log::warn!(target: "daemon", "heartbeat uptime_tick={}", tick);
+                log::debug!(target: "daemon", "heartbeat uptime_tick={}", tick);
             }
             gpu_poll_fn()
         }
@@ -361,7 +361,7 @@ async fn main() -> Result<()> {
     if let Err(e) = scheduler_handle.add_job(gpu_job) {
         log::error!("Failed to add GPU overclocking job: {}", e);
     } else {
-        log::info!("GPU overclocking polling job added");
+        log::debug!("GPU overclocking polling job added");
     }
 
     // Start DBus service
@@ -373,7 +373,7 @@ async fn main() -> Result<()> {
         }
     });
 
-    log::info!("DBus service started");
+    log::debug!("DBus service started");
 
     // Launch GUI if requested
     if launch_gui {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -83,12 +83,22 @@ impl log::Log for DaemonLogger {
     }
 
     fn log(&self, record: &log::Record) {
-        // Always capture all log levels into the buffer (Error, Warn, Info, Debug)
-        // The global max level (Debug) controls what reaches this logger
+        // Always capture all log levels into the buffer (Error, Warn, Info, Debug, Trace)
+        // The global max level (Trace) controls what reaches this logger
+
+        let mut level = record.level().to_string();
+        let target = record.target().to_string();
+        let message = record.args().to_string();
+
+        // Move messages starting with zbus:: to trace
+        if target.starts_with("zbus") || message.starts_with("zbus::") {
+            level = "TRACE".to_string();
+        }
+
         let entry = LogEntry {
-            level: record.level().to_string(),
-            target: record.target().to_string(),
-            message: record.args().to_string(),
+            level: level.clone(),
+            target: target.clone(),
+            message: message.clone(),
             timestamp: chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
         };
 
@@ -97,9 +107,9 @@ impl log::Log for DaemonLogger {
 
             // Deduplicate: avoid adding the same message twice in a row
             let is_duplicate = logs.back().map_or(false, |last| {
-                last.level == record.level().to_string() &&
-                last.target == record.target().to_string() &&
-                last.message == record.args().to_string()
+                last.level == level &&
+                last.target == target &&
+                last.message == message
             });
 
             if !is_duplicate {
@@ -133,7 +143,7 @@ async fn main() -> Result<()> {
     let logger = DaemonLogger { inner };
 
     log::set_boxed_logger(Box::new(logger)).unwrap();
-    log::set_max_level(log::LevelFilter::Debug); // Allow up to Debug to reach our logger for buffer
+    log::set_max_level(log::LevelFilter::Trace); // Allow up to Trace to reach our logger for buffer
 
     log::info!("Starting LapSphere Daemon");
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -480,7 +480,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn refresh_hardware_cache() {
+pub fn refresh_hardware_cache() {
     let cpu_info = hardware_detection::get_cpu_info().ok();
     let memory_info = hardware_detection::get_memory_info().ok();
     let gpu_info = hardware_detection::get_gpu_info().unwrap_or_default();

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -95,6 +95,11 @@ impl log::Log for DaemonLogger {
             level = "TRACE".to_string();
         }
 
+        // Move all massages hw. to info as requested
+        if target.starts_with("hw.") && level == "DEBUG" {
+            level = "INFO".to_string();
+        }
+
         let entry = LogEntry {
             level: level.clone(),
             target: target.clone(),
@@ -150,7 +155,7 @@ async fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
 
     if args.contains(&"--help".to_string()) || args.contains(&"-h".to_string()) {
-        println!("LapSphere Daemon - Hardware Control for Clevo/Uniwill Laptops");
+        println!("LapSphere Daemon - Hardware Control for Uniwill/Clevo Laptops");
         println!("\nUsage: lapsphere-daemon [OPTIONS]");
         println!("\nOptions:");
         println!("  --gui       Launch the graphical user interface");
@@ -177,7 +182,7 @@ async fn main() -> Result<()> {
     // Check if running as root
     if unsafe { libc::geteuid() } != 0 {
         if !launch_gui && !launch_tray {
-            println!("--- Hardware Statistics for Clevo/Uniwill Laptops (Limited - non-root) ---");
+            println!("--- Hardware Statistics for Uniwill/Clevo Laptops (Limited - non-root) ---");
             match hardware_detection::get_cpu_info() {
                 Ok(cpu) => {
                     println!("CPU: {}", cpu.name);
@@ -201,7 +206,7 @@ async fn main() -> Result<()> {
     }
 
     if !launch_gui && !launch_tray {
-        println!("--- Hardware Statistics for Clevo/Uniwill Laptops ---");
+        println!("--- Hardware Statistics for Uniwill/Clevo Laptops ---");
         match hardware_detection::get_cpu_info() {
             Ok(cpu) => {
                 println!("CPU: {}", cpu.name);

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -94,10 +94,20 @@ impl log::Log for DaemonLogger {
 
         {
             let mut logs = DAEMON_LOGS.lock().unwrap();
-            if logs.len() >= 2000 {
-                logs.pop_front();
+
+            // Deduplicate: avoid adding the same message twice in a row
+            let is_duplicate = logs.back().map_or(false, |last| {
+                last.level == record.level().to_string() &&
+                last.target == record.target().to_string() &&
+                last.message == record.args().to_string()
+            });
+
+            if !is_duplicate {
+                if logs.len() >= 2000 {
+                    logs.pop_front();
+                }
+                logs.push_back(entry);
             }
-            logs.push_back(entry);
         }
 
         // Only log to console if env_logger allows it
@@ -115,7 +125,7 @@ impl log::Log for DaemonLogger {
 async fn main() -> Result<()> {
     let mut builder = env_logger::Builder::from_default_env();
     if std::env::var("RUST_LOG").is_err() {
-        builder.filter_level(log::LevelFilter::Info);
+        builder.filter_level(log::LevelFilter::Warn);
         builder.filter(Some("zbus"), log::LevelFilter::Warn);
     }
     let inner = builder.build();
@@ -637,7 +647,7 @@ fn apply_gpu_overclocking(gpu_settings: &lapsphere_common::types::GpuSettings) -
             if *last != Some(0) {
                 crate::hardware_control::set_gpu_core_offset(0, 0.0)?;
                 *last = Some(0);
-                log::info!("Cleared dynamic GPU offset (P-state not 0)");
+                log::debug!("Cleared dynamic GPU offset (P-state not 0)");
             }
             drop(last);
             let mut stats = CURRENT_GPU_OVERCLOCK_STATS.lock().unwrap();
@@ -670,9 +680,9 @@ fn apply_gpu_overclocking(gpu_settings: &lapsphere_common::types::GpuSettings) -
                 crate::hardware_control::set_gpu_core_offset(0, final_offset_i32 as f32)?;
                 *last = Some(final_offset_i32);
                 if final_offset_i32 == 0 {
-                    log::info!("Cleared dynamic GPU offset (P-state not 0)");
+                    log::debug!("Cleared dynamic GPU offset (P-state not 0)");
                 } else {
-                    log::info!("Applied new dynamic GPU offset: {} MHz", final_offset_i32);
+                    log::debug!("Applied new dynamic GPU offset: {} MHz", final_offset_i32);
                 }
             }
         }

--- a/data/io.lapsphere.LapSphere.desktop
+++ b/data/io.lapsphere.LapSphere.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=LapSphere
 GenericName=Hardware Control
-Comment=Control hardware features on Clevo/Uniwill laptops
+Comment=Control hardware features on Uniwill/Clevo laptops
 Exec=lapsphere
 Icon=lapsphere
 Terminal=false

--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
          ethtool,
          iw
 Recommends: tuxedo-drivers
-Description: Hardware control application for Clevo/Uniwill laptops
+Description: Hardware control application for Uniwill/Clevo laptops
  LapSphere provides a modern interface for controlling
  hardware features on Uniwill and Clevo laptops including:
   - CPU frequency and power management

--- a/debian/lapsphere.desktop
+++ b/debian/lapsphere.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=LapSphere
 GenericName=Hardware Control
-Comment=Control hardware features on Clevo/Uniwill laptops
+Comment=Control hardware features on Uniwill/Clevo laptops
 Exec=lapsphere
 Icon=lapsphere
 Terminal=false

--- a/drivers_src/tuxedo_io/tuxedo_io.c
+++ b/drivers_src/tuxedo_io/tuxedo_io.c
@@ -34,7 +34,7 @@
 #include "../uniwill_interfaces.h"
 #include "tuxedo_io_ioctl.h"
 
-MODULE_DESCRIPTION("Hardware interface for Clevo/Uniwill laptops");
+MODULE_DESCRIPTION("Hardware interface for Uniwill/Clevo laptops");
 MODULE_AUTHOR("TUXEDO Computers GmbH <tux@tuxedocomputers.com>");
 MODULE_VERSION("0.3.9");
 MODULE_LICENSE("GPL");

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -50,9 +50,12 @@ pub struct AppState {
     pub hardware_interface: Option<String>,
     pub keyboard_capabilities: Option<KeyboardCapabilities>,
     pub gpu_clock_ranges: Option<(u32, u32)>,
+    pub gpu_clock_ranges_error: Option<String>,
     pub gpu_mem_clock_ranges: Option<(u32, u32)>,
     pub gpu_core_offset_limits: Option<(i32, i32)>,
+    pub gpu_core_offset_error: Option<String>,
     pub gpu_mem_offset_limits: Option<(i32, i32)>,
+    pub gpu_mem_offset_error: Option<String>,
     pub available_start_thresholds: Vec<u8>,
     pub available_end_thresholds: Vec<u8>,
     pub available_tdp_profiles: Vec<String>,
@@ -111,9 +114,12 @@ impl AppState {
             mount_info: Vec::new(),
             hardware_interface: None,
             gpu_clock_ranges: None,
+            gpu_clock_ranges_error: None,
             gpu_mem_clock_ranges: None,
             gpu_core_offset_limits: None,
+            gpu_core_offset_error: None,
             gpu_mem_offset_limits: None,
+            gpu_mem_offset_error: None,
             available_start_thresholds: Vec::new(),
             available_end_thresholds: Vec::new(),
             available_tdp_profiles: Vec::new(),
@@ -504,6 +510,28 @@ impl LapSphereApp {
                 }
                 HardwareUpdate::GpuInfo(info) => {
                     self.state.gpu_info = info;
+
+                    // Auto-populate ranges and limits if we found them in the periodic update
+                    if let Some(nvidia) = self.state.gpu_info.iter().find(|g| g.name.contains("NVIDIA")) {
+                        if self.state.gpu_clock_ranges.is_none() {
+                            if let Some(range) = nvidia.core_clock_range {
+                                self.state.gpu_clock_ranges = Some(range);
+                                self.state.gpu_clock_ranges_error = None;
+                            }
+                        }
+                        if self.state.gpu_core_offset_limits.is_none() {
+                            if let Some(limits) = nvidia.core_offset_limits {
+                                self.state.gpu_core_offset_limits = Some(limits);
+                                self.state.gpu_core_offset_error = None;
+                            }
+                        }
+                        if self.state.gpu_mem_offset_limits.is_none() {
+                            if let Some(limits) = nvidia.memory_offset_limits {
+                                self.state.gpu_mem_offset_limits = Some(limits);
+                                self.state.gpu_mem_offset_error = None;
+                            }
+                        }
+                    }
                 }
                 HardwareUpdate::BatteryInfo(info) => {
                     self.state.battery_info = Some(info);
@@ -579,20 +607,29 @@ impl LapSphereApp {
                 }
                 HardwareUpdate::GpuClockRanges(result) => {
                     match result {
-                        Ok(ranges) => self.state.gpu_clock_ranges = Some(ranges),
-                        Err(e) => self.state.show_message(format!("Failed to get GPU clock ranges: {}", e), true),
+                        Ok(ranges) => {
+                            self.state.gpu_clock_ranges = Some(ranges);
+                            self.state.gpu_clock_ranges_error = None;
+                        }
+                        Err(e) => self.state.gpu_clock_ranges_error = Some(e),
                     }
                 }
                 HardwareUpdate::GpuCoreOffsetLimits(result) => {
                     match result {
-                        Ok(limits) => self.state.gpu_core_offset_limits = Some(limits),
-                        Err(e) => self.state.show_message(format!("Failed to get GPU core offset limits: {}", e), true),
+                        Ok(limits) => {
+                            self.state.gpu_core_offset_limits = Some(limits);
+                            self.state.gpu_core_offset_error = None;
+                        }
+                        Err(e) => self.state.gpu_core_offset_error = Some(e),
                     }
                 }
                 HardwareUpdate::GpuMemOffsetLimits(result) => {
                     match result {
-                        Ok(limits) => self.state.gpu_mem_offset_limits = Some(limits),
-                        Err(e) => self.state.show_message(format!("Failed to get GPU memory offset limits: {}", e), true),
+                        Ok(limits) => {
+                            self.state.gpu_mem_offset_limits = Some(limits);
+                            self.state.gpu_mem_offset_error = None;
+                        }
+                        Err(e) => self.state.gpu_mem_offset_error = Some(e),
                     }
                 }
                 HardwareUpdate::AvailableThresholds(start, end) => {

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -132,7 +132,7 @@ impl AppState {
             log_filter_info: true,
             log_filter_warn: true,
             log_filter_error: true,
-            log_paused: false,
+            log_paused: true,
             log_search_text: String::new(),
             keyboard_capabilities: None,
             current_page: Page::Statistics,

--- a/gui/src/pages/settings.rs
+++ b/gui/src/pages/settings.rs
@@ -98,7 +98,7 @@ fn draw_logs_view(ui: &mut Ui, state: &mut AppState, ctx: &Context) {
 
     ui.horizontal(|ui| {
         ui.label("Line Limit:");
-        if ui.add(Slider::new(&mut state.config.log_limit, 1..=10000)).changed() {
+        if ui.add(Slider::new(&mut state.config.log_limit, 1..=2000)).changed() {
             let _ = state.save_settings();
         }
     });
@@ -122,31 +122,7 @@ fn draw_logs_view(ui: &mut Ui, state: &mut AppState, ctx: &Context) {
 
     ui.add_space(8.0);
 
-    let search_lower = state.log_search_text.to_lowercase();
-    let has_search = !search_lower.is_empty();
 
-    let filtered_logs: Vec<_> = state.daemon_logs.iter().rev().filter(|entry| {
-        let level_upper = entry.level.to_uppercase();
-        let show_level = match level_upper.as_str() {
-            "ERROR" => state.log_filter_error,
-            "WARN" | "WARNING" => state.log_filter_warn,
-            "INFO" => state.log_filter_info,
-            "DEBUG" | "TRACE" => state.log_filter_debug,
-            _ => true,
-        };
-
-        if !show_level { return false; }
-
-        if has_search {
-            entry.message.to_lowercase().contains(&search_lower) ||
-            entry.target.to_lowercase().contains(&search_lower) ||
-            entry.level.to_lowercase().contains(&search_lower)
-        } else {
-            true
-        }
-    }).collect();
-
-    let row_height = ui.text_style_height(&egui::TextStyle::Monospace);
 
     ScrollArea::vertical()
         .auto_shrink([false, false])

--- a/gui/src/pages/settings.rs
+++ b/gui/src/pages/settings.rs
@@ -204,30 +204,6 @@ fn draw_help_info(ui: &mut Ui, state: &AppState) {
                     ui.end_row();
                 });
 
-            ui.add_space(12.0);
-            ui.separator();
-            ui.add_space(12.0);
-
-            ui.add_space(6.0);
-            ui.label("Standard mode controls apply locked clocks and memory offsets directly.");
-            ui.label("They are applied when you click Save in the Tuning tab.");
-
-            ui.add_space(12.0);
-            ui.separator();
-            ui.add_space(12.0);
-
-            ui.add_space(6.0);
-            let advanced_enabled = state
-                .current_profile()
-                .map(|profile| profile.gpu_settings.advanced_control)
-                .unwrap_or(false);
-            if advanced_enabled {
-                ui.label("Advanced dynamic offsets are enabled for the current profile.");
-            } else {
-                ui.label("Advanced dynamic offsets are disabled for the current profile.");
-            }
-            ui.label("Advanced mode uses its own locked clock and memory offset values.");
-            ui.label("Press F1 for the NVIDIA overclocking parameter reference.");
         });
 }
 
@@ -237,7 +213,7 @@ fn draw_about_info(ui: &mut Ui, state: &AppState) {
         .show(ui, |ui| {
             ui.label(RichText::new("About").strong().heading());
             ui.add_space(6.0);
-            ui.label("LapSphere provides hardware monitoring and tuning for Clevo/Uniwill laptops.");
+            ui.label("LapSphere provides hardware monitoring and tuning for Uniwill/Clevo laptops.");
             ui.label("Use the Profiles and Tuning tabs to customize performance, cooling, and lighting.");
             ui.label("Statistics and Hardware Info show live system telemetry.");
 

--- a/gui/src/pages/settings.rs
+++ b/gui/src/pages/settings.rs
@@ -124,48 +124,55 @@ fn draw_logs_view(ui: &mut Ui, state: &mut AppState, ctx: &Context) {
 
 
 
+    let search_lower = state.log_search_text.to_lowercase();
+    let has_search = !search_lower.is_empty();
+
+    let filtered_logs: Vec<_> = state.daemon_logs.iter().rev()
+        .filter(|entry| {
+            let level_upper = entry.level.to_uppercase();
+            let show_level = match level_upper.as_str() {
+                "ERROR" => state.log_filter_error,
+                "WARN" | "WARNING" => state.log_filter_warn,
+                "INFO" => state.log_filter_info,
+                "DEBUG" => state.log_filter_debug,
+                "TRACE" => state.log_filter_trace,
+                _ => true,
+            };
+
+            if !show_level { return false; }
+
+            if has_search {
+                entry.message.to_lowercase().contains(&search_lower) ||
+                entry.target.to_lowercase().contains(&search_lower) ||
+                entry.level.to_lowercase().contains(&search_lower)
+            } else {
+                true
+            }
+        })
+        .take(state.config.log_limit)
+        .collect();
+
+    let row_height = ui.text_style_height(&egui::TextStyle::Monospace);
     ScrollArea::vertical()
         .auto_shrink([false, false])
-        .show(ui, |ui| {
-            let search_lower = state.log_search_text.to_lowercase();
-            let has_search = !search_lower.is_empty();
-            
-            for entry in state.daemon_logs.iter().rev().take(state.config.log_limit) {
+        .show_rows(ui, row_height, filtered_logs.len(), |ui, row_range| {
+            for i in row_range {
+                let entry = filtered_logs[i];
                 let level_upper = entry.level.to_uppercase();
-                let show_level = match level_upper.as_str() {
-                    "ERROR" => state.log_filter_error,
-                    "WARN" | "WARNING" => state.log_filter_warn,
-                    "INFO" => state.log_filter_info,
-                    "DEBUG" => state.log_filter_debug,
-                    "TRACE" => state.log_filter_trace,
-                    _ => true,
+                let color = match level_upper.as_str() {
+                    "ERROR" => egui::Color32::from_rgb(255, 100, 100),
+                    "WARN" | "WARNING" => egui::Color32::from_rgb(255, 200, 100),
+                    "DEBUG" => egui::Color32::from_rgb(150, 150, 150),
+                    "TRACE" => egui::Color32::from_rgb(100, 100, 100),
+                    _ => ui.visuals().text_color(),
                 };
 
-                // Apply search filter
-                let show_search = if has_search {
-                    entry.message.to_lowercase().contains(&search_lower) ||
-                    entry.target.to_lowercase().contains(&search_lower) ||
-                    entry.level.to_lowercase().contains(&search_lower)
-                } else {
-                    true
-                };
-
-                if show_level && show_search {
-                    let color = match level_upper.as_str() {
-                        "ERROR" => egui::Color32::from_rgb(255, 100, 100),
-                        "WARN" | "WARNING" => egui::Color32::from_rgb(255, 200, 100),
-                        "DEBUG" => egui::Color32::from_rgb(150, 150, 150),
-                        "TRACE" => egui::Color32::from_rgb(100, 100, 100),
-                        _ => ui.visuals().text_color(),
-                    };
-
-                    ui.horizontal_top(|ui| {
-                        ui.label(RichText::new(&entry.timestamp).weak().monospace());
-                        ui.label(RichText::new(&entry.level).color(color).strong().monospace());
-                        ui.label(RichText::new(&entry.target).color(egui::Color32::from_rgb(100, 150, 255)).monospace());
-                        ui.label(RichText::new(&entry.message).monospace());
-                    });
-                }
+                ui.horizontal_top(|ui| {
+                    ui.label(RichText::new(&entry.timestamp).weak().monospace());
+                    ui.label(RichText::new(&entry.level).color(color).strong().monospace());
+                    ui.label(RichText::new(&entry.target).color(egui::Color32::from_rgb(100, 150, 255)).monospace());
+                    ui.label(RichText::new(&entry.message).monospace());
+                });
             }
         });
 }

--- a/gui/src/pages/tuning.rs
+++ b/gui/src/pages/tuning.rs
@@ -470,8 +470,8 @@ fn draw_gpu_tuning(
         let nvidia_gpu = gpu_info.iter().find(|g| g.name.contains("NVIDIA"));
         let nvml_index = nvidia_gpu.and_then(|g| g.nvml_index).unwrap_or(0);
 
-        // Fetch ranges if they haven't been fetched yet
-        if state.gpu_clock_ranges.is_none() {
+        // Fetch ranges if they haven't been fetched yet and there was no error
+        if state.gpu_clock_ranges.is_none() && state.gpu_clock_ranges_error.is_none() {
             if let Some(client) = dbus_client {
                 let client = client.clone();
                 let tx = hw_update_tx.clone();
@@ -483,7 +483,7 @@ fn draw_gpu_tuning(
                 });
             }
         }
-        if state.gpu_core_offset_limits.is_none() {
+        if state.gpu_core_offset_limits.is_none() && state.gpu_core_offset_error.is_none() {
             if let Some(client) = dbus_client {
                 let client = client.clone();
                 let tx = hw_update_tx.clone();
@@ -495,7 +495,7 @@ fn draw_gpu_tuning(
                 });
             }
         }
-        if state.gpu_mem_offset_limits.is_none() {
+        if state.gpu_mem_offset_limits.is_none() && state.gpu_mem_offset_error.is_none() {
             if let Some(client) = dbus_client {
                 let client = client.clone();
                 let tx = hw_update_tx.clone();
@@ -522,9 +522,11 @@ fn draw_gpu_tuning(
                     ui,
                     profile,
                     state.gpu_clock_ranges,
+                    state.gpu_clock_ranges_error.clone(),
                     state.gpu_mem_clock_ranges,
                     state.gpu_core_offset_limits,
                     state.gpu_mem_offset_limits,
+                    state.gpu_mem_offset_error.clone(),
                     gpu,
                     dbus_client,
                     hw_update_tx.clone(),
@@ -542,8 +544,10 @@ fn draw_gpu_tuning(
                 profile,
                 &mut gpu_oc_poll,
                 state.gpu_clock_ranges,
+                state.gpu_clock_ranges_error.clone(),
                 None,
                 state.gpu_mem_offset_limits,
+                state.gpu_mem_offset_error.clone(),
                 nvidia_gpu_ref.as_ref(),
                 dbus_client,
                 hw_update_tx.clone(),
@@ -570,9 +574,11 @@ fn draw_gpu_standard_controls(
     ui: &mut Ui,
     profile: &mut Profile,
     gpu_clock_ranges: Option<(u32, u32)>,
+    gpu_clock_ranges_error: Option<String>,
     _gpu_mem_clock_ranges: Option<(u32, u32)>,
     gpu_core_offset_limits: Option<(i32, i32)>,
     gpu_mem_offset_limits: Option<(i32, i32)>,
+    gpu_mem_offset_error: Option<String>,
     gpu_info: &lapsphere_common::types::GpuInfo,
     dbus_client: Option<&DbusClient>,
     hw_update_tx: tokio::sync::mpsc::Sender<crate::app::HardwareUpdate>,
@@ -668,6 +674,8 @@ fn draw_gpu_standard_controls(
 
         profile.gpu_settings.min_gpu_clock = Some(min_gpu_clock);
         profile.gpu_settings.max_gpu_clock = Some(max_gpu_clock);
+    } else if let Some(err) = &gpu_clock_ranges_error {
+        ui.label(RichText::new(format!("GPU clock ranges: {}", err)).small().weak());
     } else {
         ui.label("Fetching GPU clock ranges...");
     }
@@ -689,6 +697,8 @@ fn draw_gpu_standard_controls(
                 }
             }
             profile.gpu_settings.memory_offset = Some(memory_offset);
+        } else if let Some(err) = &gpu_mem_offset_error {
+            ui.label(RichText::new(format!("GPU memory offset limits: {}", err)).small().weak());
         } else {
             ui.label("Fetching GPU memory offset limits...");
         }
@@ -724,8 +734,10 @@ fn draw_gpu_advanced_controls(
     profile: &mut Profile,
     gpu_overclock_poll_rate: &mut u64,
     gpu_clock_ranges: Option<(u32, u32)>,
+    gpu_clock_ranges_error: Option<String>,
     _gpu_mem_clock_ranges: Option<(u32, u32)>,
     gpu_mem_offset_limits: Option<(i32, i32)>,
+    gpu_mem_offset_error: Option<String>,
     gpu_info: Option<&lapsphere_common::types::GpuInfo>,
     dbus_client: Option<&DbusClient>,
     hw_update_tx: tokio::sync::mpsc::Sender<crate::app::HardwareUpdate>,
@@ -780,9 +792,11 @@ fn draw_gpu_advanced_controls(
             });
             profile.gpu_settings.advanced_min_gpu_clock = Some(min_gpu_clock);
             profile.gpu_settings.advanced_max_gpu_clock = Some(max_gpu_clock);
+        } else if let Some(err) = &gpu_clock_ranges_error {
+            ui.label(RichText::new(format!("GPU clock ranges: {}", err)).small().weak());
         } else {
             ui.label("Fetching GPU clock ranges...");
-    }
+        }
 
     ui.add_space(8.0);
     ui.label(RichText::new("GPU Memory Offset (Advanced):").strong());
@@ -798,6 +812,8 @@ fn draw_gpu_advanced_controls(
             }
         }
         profile.gpu_settings.advanced_memory_offset = Some(advanced_mem_offset);
+    } else if let Some(err) = &gpu_mem_offset_error {
+        ui.label(RichText::new(format!("GPU memory offset limits: {}", err)).small().weak());
     } else {
         ui.label("Fetching GPU memory offset limits...");
     }


### PR DESCRIPTION
The daemon now logs only state changes or errors at the default info level, with frequent hardware discovery and heartbeat messages moved to debug level. The GUI log display limit is now capped at 2000 lines. GPU clock ranges and offset limits are now cached upon first discovery or when the GPU wakes up, ensuring the Statistics tab displays these values immediately without hanging or unnecessarily waking the hardware.

---
*PR created automatically by Jules for task [12557062976475615457](https://jules.google.com/task/12557062976475615457) started by @weter11*